### PR TITLE
Change analytics.js in the example to load via HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ga('create', 'UA-XXXXX-Y', 'auto');
 ga('require', 'autotrack');
 ga('send', 'pageview');
 </script>
-<script async src='//www.google-analytics.com/analytics.js'></script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
 <script async src='path/to/autotrack.js'></script>
 ```
 


### PR DESCRIPTION
It's recommended for lots of reasons to always load external scripts via HTTPS. We should recommend users to load analytics.js via HTTPS here.