### PR TITLE
Fix <forms> without action attr

### DIFF
--- a/lib/plugins/outbound-form-tracker.js
+++ b/lib/plugins/outbound-form-tracker.js
@@ -85,7 +85,7 @@ OutboundFormTracker.prototype.handleFormSubmits = function(event) {
  */
 OutboundFormTracker.prototype.shouldTrackOutboundForm = function(form) {
   var action = form.getAttribute('action');
-  return action.indexOf('http') === 0 && action.indexOf(location.hostname) < 0;
+  return action && action.indexOf('http') === 0 && action.indexOf(location.hostname) < 0;
 };
 
 


### PR DESCRIPTION
This'll work around the current issue of `cannot read property 'indexOf' of null` when forms don't have a target attribute set.

In my case, this came up as part of a React project that doesn't support universal rendering.

![screenshot 2016-03-02 09 08 58](https://cloud.githubusercontent.com/assets/192263/13468492/a60ca4d4-e057-11e5-9698-748d36291d6a.png)

Edit: CLA signed