### PR TITLE
Remove unnecessary caught errors

### DIFF
--- a/lib/plugins/media-query-tracker.js
+++ b/lib/plugins/media-query-tracker.js
@@ -67,35 +67,29 @@ function MediaQueryTracker(tracker, opts) {
  * and adds the change listeners.
  */
 MediaQueryTracker.prototype.processMediaQueries = function() {
-  this.opts.mediaQueryDefinitions.forEach(function(dimension) {
+  this.opts.mediaQueryDefinitions.forEach(function(definition) {
+    // Only processes definitions with a name and index.
+    if (definition.name && definition.dimensionIndex) {
+      var mediaName = this.getMatchName(definition);
+      this.tracker.set('dimension' + definition.dimensionIndex, mediaName);
 
-    if (!dimension.dimensionIndex) {
-      throw new Error('Media query definitions must have a name.');
+      this.addChangeListeners(definition);
     }
-
-    if (!dimension.dimensionIndex) {
-      throw new Error('Media query definitions must have a dimension index.');
-    }
-
-    var name = this.getMatchName(dimension);
-    this.tracker.set('dimension' + dimension.dimensionIndex, name);
-
-    this.addChangeListeners(dimension);
   }.bind(this));
 };
 
 
 /**
- * Takes a dimension object and return the name of the matching media item.
+ * Takes a definition object and return the name of the matching media item.
  * If no match is found, the NULL_DIMENSION value is returned.
  * @param {Object} dimension A set of named media queries associated
  *     with a single custom dimension.
  * @return {string} The name of the matched media or NULL_DIMENSION.
  */
-MediaQueryTracker.prototype.getMatchName = function(dimension) {
+MediaQueryTracker.prototype.getMatchName = function(definition) {
   var match;
 
-  dimension.items.forEach(function(item) {
+  definition.items.forEach(function(item) {
     if (getMediaListener(item.media).matches) {
       match = item;
     }
@@ -105,16 +99,16 @@ MediaQueryTracker.prototype.getMatchName = function(dimension) {
 
 
 /**
- * Adds change listeners to each media query in the dimension list.
+ * Adds change listeners to each media query in the definition list.
  * Debounces the changes to prevent unnecessary hits from being sent.
- * @param {Object} dimension A set of named media queries associated
+ * @param {Object} definition A set of named media queries associated
  *     with a single custom dimension
  */
-MediaQueryTracker.prototype.addChangeListeners = function(dimension) {
-  dimension.items.forEach(function(item) {
+MediaQueryTracker.prototype.addChangeListeners = function(definition) {
+  definition.items.forEach(function(item) {
     var mql = getMediaListener(item.media);
     var fn = debounce(function() {
-      this.handleChanges(dimension);
+      this.handleChanges(definition);
     }.bind(this), this.opts.mediaQueryChangeTimeout);
 
     mql.addListener(fn);
@@ -126,16 +120,16 @@ MediaQueryTracker.prototype.addChangeListeners = function(dimension) {
 /**
  * Handles changes to the matched media. When the new value differs from
  * the old value, a change event is sent.
- * @param {Object} dimension A set of named media queries associated
+ * @param {Object} definition A set of named media queries associated
  *     with a single custom dimension
  */
-MediaQueryTracker.prototype.handleChanges = function(dimension) {
-  var newValue = this.getMatchName(dimension);
-  var oldValue = this.tracker.get('dimension' + dimension.dimensionIndex);
+MediaQueryTracker.prototype.handleChanges = function(definition) {
+  var newValue = this.getMatchName(definition);
+  var oldValue = this.tracker.get('dimension' + definition.dimensionIndex);
 
   if (newValue !== oldValue) {
-    this.tracker.set('dimension' + dimension.dimensionIndex, newValue);
-    this.tracker.send('event', dimension.name, 'change',
+    this.tracker.set('dimension' + definition.dimensionIndex, newValue);
+    this.tracker.send('event', definition.name, 'change',
         this.opts.mediaQueryChangeTemplate(oldValue, newValue));
   }
 };


### PR DESCRIPTION
`analytics.js` initializes plugins in a try/catch block, so throwing errors is pointless and just takes up necessary bytes.