### PR TITLE
Fix a history change bug in IE11

### DIFF
--- a/lib/plugins/url-change-tracker.js
+++ b/lib/plugins/url-change-tracker.js
@@ -46,25 +46,25 @@ function UrlChangeTracker(tracker, opts) {
 
   // Overrides history.pushState.
   this.originalPushState = history.pushState;
-  history.pushState = function(state, title, url) {
+  history.pushState = function(state, title) {
     // Sets the document title for reference later.
     // TODO(philipwalton): consider using WeakMap for this to not conflict
     // with any user-defined property also called "title".
     if (isObject(state) && title) state.title = title;
 
-    this.originalPushState.call(history, state, title, url);
+    this.originalPushState.apply(history, arguments);
     this.updateTrackerData();
   }.bind(this);
 
   // Overrides history.repaceState.
   this.originalReplaceState = history.replaceState;
-  history.replaceState = function(state, title, url) {
+  history.replaceState = function(state, title) {
     // Sets the document title for reference later.
     // TODO(philipwalton): consider using WeakMap for this to not conflict
     // with any user-defined property also called "title".
     if (isObject(state) && title) state.title = title;
 
-    this.originalReplaceState.call(history, state, title, url);
+    this.originalReplaceState.apply(history, arguments);
     this.updateTrackerData(false);
   }.bind(this);
 


### PR DESCRIPTION
Passing the `url` as explicitly `undefined` [causes problems in IE11](#54).

This change calls the original push and replace state functions with their original arguments rather than passing the three argument individually.