### PR TITLE
Give element and attribute access to all plugins

### DIFF
--- a/lib/plugins/clean-url-tracker.js
+++ b/lib/plugins/clean-url-tracker.js
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-
+var assign = require('object-assign');
 var parseUrl = require('dom-utils/lib/parse-url');
 var constants = require('../constants');
 var provide = require('../provide');
-var defaults = require('../utilities').defaults;
 
 
 /**
@@ -32,12 +31,12 @@ var defaults = require('../utilities').defaults;
  */
 function CleanUrlTracker(tracker, opts) {
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     stripQuery: true,
     queryDimensionIndex: null,
     indexFilename: null,
     trailingSlash: null
-  });
+  }, opts);
 
   this.tracker = tracker;
 

--- a/lib/plugins/event-tracker.js
+++ b/lib/plugins/event-tracker.js
@@ -15,12 +15,12 @@
  */
 
 
+var assign = require('object-assign');
 var delegate = require('dom-utils/lib/delegate');
 var getAttributes = require('dom-utils/lib/get-attributes');
 var provide = require('../provide');
 var camelCase = require('../utilities').camelCase;
 var createFieldsObj = require('../utilities').createFieldsObj;
-var defaults = require('../utilities').defaults;
 
 
 /**
@@ -34,12 +34,12 @@ function EventTracker(tracker, opts) {
   // Feature detects to prevent errors in unsupporting browsers.
   if (!window.addEventListener) return;
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     events: ['click'],
     attributePrefix: 'ga-',
     fieldsObj: null,
     hitFilter: null
-  });
+  }, opts);
 
   this.tracker = tracker;
 

--- a/lib/plugins/event-tracker.js
+++ b/lib/plugins/event-tracker.js
@@ -17,11 +17,9 @@
 
 var assign = require('object-assign');
 var delegate = require('dom-utils/lib/delegate');
-var getAttributes = require('dom-utils/lib/get-attributes');
 var provide = require('../provide');
-var camelCase = require('../utilities').camelCase;
 var createFieldsObj = require('../utilities').createFieldsObj;
-
+var getAttributeFields = require('../utilities').getAttributeFields;
 
 /**
  * Registers declarative event tracking.
@@ -69,21 +67,7 @@ EventTracker.prototype.handleEvents = function(event, element) {
   // Ensures the event type matches the one specified on the element.
   if (event.type != element.getAttribute(prefix + 'on')) return;
 
-  var defaultFields = {};
-  var attributes = getAttributes(element);
-
-  Object.keys(attributes).forEach(function(attribute) {
-    if (attribute.indexOf(prefix) === 0 && attribute != prefix + 'on') {
-      var value = attributes[attribute];
-
-      // Detects Boolean value strings.
-      if (value == 'true') value = true;
-      if (value == 'false') value = false;
-
-      var field = camelCase(attribute.slice(prefix.length));
-      defaultFields[field] = value;
-    }
-  });
+  var defaultFields = getAttributeFields(element, prefix);
 
   this.tracker.send(defaultFields.hitType || 'event', createFieldsObj(
       defaultFields, this.opts.fieldsObj, this.tracker, this.opts.hitFilter));

--- a/lib/plugins/event-tracker.js
+++ b/lib/plugins/event-tracker.js
@@ -21,6 +21,7 @@ var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
 var getAttributeFields = require('../utilities').getAttributeFields;
 
+
 /**
  * Registers declarative event tracking.
  * @constructor
@@ -35,7 +36,7 @@ function EventTracker(tracker, opts) {
   this.opts = assign({
     events: ['click'],
     attributePrefix: 'ga-',
-    fieldsObj: null,
+    fieldsObj: {},
     hitFilter: null
   }, opts);
 
@@ -67,10 +68,13 @@ EventTracker.prototype.handleEvents = function(event, element) {
   // Ensures the event type matches the one specified on the element.
   if (event.type != element.getAttribute(prefix + 'on')) return;
 
-  var defaultFields = getAttributeFields(element, prefix);
+  var defaultFields = {transport: 'beacon'};
+  var attributeFields = getAttributeFields(element, prefix);
+  var userFields = assign({}, this.opts.fieldsObj, attributeFields);
+  var hitType = attributeFields.hitType || 'event';
 
-  this.tracker.send(defaultFields.hitType || 'event', createFieldsObj(
-      defaultFields, this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
+  this.tracker.send(hitType, createFieldsObj(
+      defaultFields, userFields, this.tracker, this.opts.hitFilter, element));
 };
 
 

--- a/lib/plugins/media-query-tracker.js
+++ b/lib/plugins/media-query-tracker.js
@@ -15,11 +15,11 @@
  */
 
 
+var assign = require('object-assign');
 var debounce = require('debounce');
 var constants = require('../constants');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
-var defaults = require('../utilities').defaults;
 var isObject = require('../utilities').isObject;
 var toArray = require('../utilities').toArray;
 
@@ -41,13 +41,13 @@ function MediaQueryTracker(tracker, opts) {
   // Feature detects to prevent errors in unsupporting browsers.
   if (!window.matchMedia) return;
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     definitions: false,
     changeTemplate: this.changeTemplate,
     changeTimeout: 1000,
     fieldsObj: null,
     hitFilter: null
-  });
+  }, opts);
 
   // Exits early if media query data doesn't exist.
   if (!isObject(this.opts.definitions)) return;

--- a/lib/plugins/media-query-tracker.js
+++ b/lib/plugins/media-query-tracker.js
@@ -45,7 +45,7 @@ function MediaQueryTracker(tracker, opts) {
     definitions: false,
     changeTemplate: this.changeTemplate,
     changeTimeout: 1000,
-    fieldsObj: null,
+    fieldsObj: {},
     hitFilter: null
   }, opts);
 
@@ -133,8 +133,8 @@ MediaQueryTracker.prototype.handleChanges = function(definition) {
       eventAction: 'change',
       eventLabel: this.opts.changeTemplate(oldValue, newValue)
     };
-    this.tracker.send('event', createFieldsObj(defaultFields,
-        this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
+    this.tracker.send('event', createFieldsObj(
+        defaultFields, this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
   }
 };
 

--- a/lib/plugins/outbound-form-tracker.js
+++ b/lib/plugins/outbound-form-tracker.js
@@ -20,6 +20,7 @@ var delegate = require('dom-utils/lib/delegate');
 var parseUrl = require('dom-utils/lib/parse-url');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
+var getAttributeFields = require('../utilities').getAttributeFields;
 var withTimeout = require('../utilities').withTimeout;
 
 
@@ -37,7 +38,7 @@ function OutboundFormTracker(tracker, opts) {
   this.opts = assign({
     formSelector: 'form',
     shouldTrackOutboundForm: this.shouldTrackOutboundForm,
-    fieldsObj: null,
+    fieldsObj: {},
     hitFilter: null
   }, opts);
 
@@ -60,7 +61,12 @@ function OutboundFormTracker(tracker, opts) {
 OutboundFormTracker.prototype.handleFormSubmits = function(event, form) {
 
   var action = parseUrl(form.action).href;
-  var fieldsObj = {transport: 'beacon'};
+  var defaultFields = {
+    transport: 'beacon',
+    eventCategory: 'Outbound Form',
+    eventAction: 'submit',
+    eventLabel: action
+  };
 
   if (this.opts.shouldTrackOutboundForm(form, parseUrl)) {
 
@@ -68,19 +74,15 @@ OutboundFormTracker.prototype.handleFormSubmits = function(event, form) {
       // Stops the submit and waits until the hit is complete (with timeout)
       // for browsers that don't support beacon.
       event.preventDefault();
-      fieldsObj.hitCallback = withTimeout(function() {
+      defaultFields.hitCallback = withTimeout(function() {
         form.submit();
       });
     }
 
-    var defaultFields = {
-      transport: 'beacon',
-      eventCategory: 'Outbound Form',
-      eventAction: 'submit',
-      eventLabel: action
-    };
-    this.tracker.send('event', createFieldsObj(defaultFields,
-        this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
+    var userFields = assign({}, this.opts.fieldsObj, getAttributeFields(form));
+
+    this.tracker.send('event', createFieldsObj(
+        defaultFields, userFields, this.tracker, this.opts.hitFilter, form));
   }
 };
 

--- a/lib/plugins/outbound-form-tracker.js
+++ b/lib/plugins/outbound-form-tracker.js
@@ -15,11 +15,11 @@
  */
 
 
+var assign = require('object-assign');
 var delegate = require('dom-utils/lib/delegate');
 var parseUrl = require('dom-utils/lib/parse-url');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
-var defaults = require('../utilities').defaults;
 var withTimeout = require('../utilities').withTimeout;
 
 
@@ -34,12 +34,12 @@ function OutboundFormTracker(tracker, opts) {
   // Feature detects to prevent errors in unsupporting browsers.
   if (!window.addEventListener) return;
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     formSelector: 'form',
     shouldTrackOutboundForm: this.shouldTrackOutboundForm,
     fieldsObj: null,
     hitFilter: null
-  });
+  }, opts);
 
   this.tracker = tracker;
 

--- a/lib/plugins/outbound-link-tracker.js
+++ b/lib/plugins/outbound-link-tracker.js
@@ -15,11 +15,11 @@
  */
 
 
+var assign = require('object-assign');
 var delegate = require('dom-utils/lib/delegate');
 var parseUrl = require('dom-utils/lib/parse-url');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
-var defaults = require('../utilities').defaults;
 
 
 /**
@@ -33,12 +33,12 @@ function OutboundLinkTracker(tracker, opts) {
   // Feature detects to prevent errors in unsupporting browsers.
   if (!window.addEventListener) return;
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     linkSelector: 'a',
     shouldTrackOutboundLink: this.shouldTrackOutboundLink,
     fieldsObj: null,
     hitFilter: null
-  });
+  }, opts);
 
   this.tracker = tracker;
 

--- a/lib/plugins/outbound-link-tracker.js
+++ b/lib/plugins/outbound-link-tracker.js
@@ -20,6 +20,7 @@ var delegate = require('dom-utils/lib/delegate');
 var parseUrl = require('dom-utils/lib/parse-url');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
+var getAttributeFields = require('../utilities').getAttributeFields;
 
 
 /**
@@ -36,7 +37,7 @@ function OutboundLinkTracker(tracker, opts) {
   this.opts = assign({
     linkSelector: 'a',
     shouldTrackOutboundLink: this.shouldTrackOutboundLink,
-    fieldsObj: null,
+    fieldsObj: {},
     hitFilter: null
   }, opts);
 
@@ -70,8 +71,10 @@ OutboundLinkTracker.prototype.handleLinkClicks = function(event, link) {
       eventAction: 'click',
       eventLabel: link.href
     };
-    this.tracker.send('event', createFieldsObj(defaultFields,
-        this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
+    var userFields = assign({}, this.opts.fieldsObj, getAttributeFields(link));
+
+    this.tracker.send('event', createFieldsObj(
+        defaultFields, userFields, this.tracker, this.opts.hitFilter, link));
   }
 };
 

--- a/lib/plugins/page-visibility-tracker.js
+++ b/lib/plugins/page-visibility-tracker.js
@@ -15,9 +15,9 @@
  */
 
 
+var assign = require('object-assign');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
-var defaults = require('../utilities').defaults;
 var isObject = require('../utilities').isObject;
 
 
@@ -35,14 +35,14 @@ function PageVisibilityTracker(tracker, opts) {
   // Feature detects to prevent errors in unsupporting browsers.
   if (!window.addEventListener) return;
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     visibleMetricIndex: null,
     hiddenMetricIndex: null,
     sessionTimeout: DEFAULT_SESSION_TIMEOUT,
     changeTemplate: this.changeTemplate,
     fieldsObj: null,
     hitFilter: null
-  });
+  }, opts);
 
   this.tracker = tracker;
   this.visibilityState = document.visibilityState;

--- a/lib/plugins/page-visibility-tracker.js
+++ b/lib/plugins/page-visibility-tracker.js
@@ -40,7 +40,7 @@ function PageVisibilityTracker(tracker, opts) {
     hiddenMetricIndex: null,
     sessionTimeout: DEFAULT_SESSION_TIMEOUT,
     changeTemplate: this.changeTemplate,
-    fieldsObj: null,
+    fieldsObj: {},
     hitFilter: null
   }, opts);
 

--- a/lib/plugins/social-widget-tracker.js
+++ b/lib/plugins/social-widget-tracker.js
@@ -18,9 +18,9 @@
 /* global FB, twttr */
 
 
+var assign = require('object-assign');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
-var defaults = require('../utilities').defaults;
 
 
 /**
@@ -36,10 +36,10 @@ function SocialWidgetTracker(tracker, opts) {
   // Feature detects to prevent errors in unsupporting browsers.
   if (!window.addEventListener) return;
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     fieldsObj: null,
     hitFilter: null
-  });
+  }, opts);
 
   this.tracker = tracker;
 

--- a/lib/plugins/social-widget-tracker.js
+++ b/lib/plugins/social-widget-tracker.js
@@ -37,7 +37,7 @@ function SocialWidgetTracker(tracker, opts) {
   if (!window.addEventListener) return;
 
   this.opts = assign({
-    fieldsObj: null,
+    fieldsObj: {},
     hitFilter: null
   }, opts);
 

--- a/lib/plugins/url-change-tracker.js
+++ b/lib/plugins/url-change-tracker.js
@@ -15,9 +15,9 @@
  */
 
 
+var assign = require('object-assign');
 var provide = require('../provide');
 var createFieldsObj = require('../utilities').createFieldsObj;
-var defaults = require('../utilities').defaults;
 var isObject = require('../utilities').isObject;
 
 
@@ -32,11 +32,11 @@ function UrlChangeTracker(tracker, opts) {
   // Feature detects to prevent errors in unsupporting browsers.
     if (!history.pushState || !window.addEventListener) return;
 
-  this.opts = defaults(opts, {
+  this.opts = assign({
     shouldTrackUrlChange: this.shouldTrackUrlChange,
     fieldsObj: null,
     hitFilter: null
-  });
+  }, opts);
 
   this.tracker = tracker;
 

--- a/lib/plugins/url-change-tracker.js
+++ b/lib/plugins/url-change-tracker.js
@@ -34,7 +34,7 @@ function UrlChangeTracker(tracker, opts) {
 
   this.opts = assign({
     shouldTrackUrlChange: this.shouldTrackUrlChange,
-    fieldsObj: null,
+    fieldsObj: {},
     hitFilter: null
   }, opts);
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -23,42 +23,30 @@ var utilities = {
 
 
   /**
-   * Accepts default and user override fields and an optional tracker and hit
-   * filter and returns a single object that can be used in ga('send') commands.
+   * Accepts default and user override fields and an optional tracker, hit
+   * filter, and target element and returns a single object that can be used in
+   * `ga('send', ...)` commands.
    * @param {Object} defaultFields The default fields to return.
    * @param {Object} userFields Fields set by the user to override the defaults.
    * @param {Object} opt_tracker The tracker object to apply the hit filter to.
    * @param {Function} opt_hitFilter A filter function that gets
    *     called with the tracker model right before the `buildHitTask`. It can
    *     be used to modify the model for the current hit only.
+   * @param {Element} opt_target If the hit originated from an interaction
+   *     with a DOM element, hitFilter is invoked with that element as the
+   *     second argument.
    * @return {Object} The final fields object.
    */
-  createFieldsObj: function(defaultFields, userFields,
-      opt_tracker, opt_hitFilter) {
-
-    if (!utilities.isObject(defaultFields)) defaultFields = {};
-    if (!utilities.isObject(userFields)) userFields = {};
+  createFieldsObj: function(
+      defaultFields, userFields, opt_tracker, opt_hitFilter, opt_target) {
 
     if (typeof opt_hitFilter == 'function') {
       var originalBuildHitTask = opt_tracker.get('buildHitTask');
       return {
         buildHitTask: function(model) {
-          var field;
-          // TODO(philipwalton): model fields cannot currently be set as an
-          // object in temporary mode. This will hopefully be fixed soon.
-          // model.set(defaultFields, true);
-          // model.set(userFields, true);
-          for (field in defaultFields) {
-            if (defaultFields.hasOwnProperty(field)) {
-              model.set(field, defaultFields[field], true);
-            }
-          }
-          for (field in userFields) {
-            if (userFields.hasOwnProperty(field)) {
-              model.set(field, userFields[field], true);
-            }
-          }
-          opt_hitFilter(model);
+          model.set(defaultFields, null, true);
+          model.set(userFields, null, true);
+          opt_hitFilter(model, opt_target);
           originalBuildHitTask(model);
         }
       };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -16,6 +16,7 @@
 
 
 var assign = require('object-assign');
+var getAttributes = require('dom-utils/lib/get-attributes');
 
 
 var utilities = {
@@ -69,6 +70,38 @@ var utilities = {
 
 
   /**
+   * Retrieves the attributes from an DOM element and returns a fields object
+   * for all attributes matching the passed prefix string.
+   * @param {Element} element The DOM element to get attributes from.
+   * @param {string} prefix An attribute prefix. Only the attributes matching
+   *     the prefix will be returned on the fields object.
+   * @return {Object} An object of analytics.js fields and values
+   */
+  getAttributeFields: function(element, prefix) {
+    var attributes = getAttributes(element);
+    var attributeFields = {};
+
+    Object.keys(attributes).forEach(function(attribute) {
+
+      // The `on` prefix is used for event handling but isn't a field.
+      if (attribute.indexOf(prefix) === 0 && attribute != prefix + 'on') {
+
+        var value = attributes[attribute];
+
+        // Detects Boolean value strings.
+        if (value == 'true') value = true;
+        if (value == 'false') value = false;
+
+        var field = utilities.camelCase(attribute.slice(prefix.length));
+        attributeFields[field] = value;
+      }
+    });
+
+    return attributeFields;
+  },
+
+
+  /**
    * Accepts a function and returns a wrapped version of the function that is
    * expected to be called elsewhere in the system. If it's not called
    * elsewhere after the timeout period, it's called regardless. The wrapper
@@ -90,6 +123,12 @@ var utilities = {
   },
 
 
+  /**
+   * Accepts a string containing hyphen or underscore word separators and
+   * converts it to camelCase.
+   * @param {string} str The string to camelCase.
+   * @return {string} The camelCased version of the string.
+   */
   camelCase: function(str) {
     return str.replace(/[\-\_]+(\w?)/g, function(match, p1) {
       return p1.toUpperCase();

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -90,29 +90,6 @@ var utilities = {
   },
 
 
-  /**
-   * Accepts an object of overrides and defaults and returns a new object
-   * with the values merged. For each key in defaults, if there's a
-   * corresponding value in overrides, it gets used.
-   * @param {Object} overrides The object with properties to override.
-   * @param {?Object} defaults The object with properties to use as defaults.
-   * @return {Object} The final, merged object.
-   */
-  defaults: function(overrides, defaults) {
-    var result = {};
-    if (!utilities.isObject(overrides)) overrides = {};
-    if (!utilities.isObject(defaults)) defaults = {};
-
-    for (var key in defaults) {
-      if (defaults.hasOwnProperty(key)) {
-        result[key] = overrides.hasOwnProperty(key) ?
-            overrides[key] : defaults[key];
-      }
-    }
-    return result;
-  },
-
-
   camelCase: function(str) {
     return str.replace(/[\-\_]+(\w?)/g, function(match, p1) {
       return p1.toUpperCase();

--- a/test/event-tracker.js
+++ b/test/event-tracker.js
@@ -170,8 +170,8 @@ describe('eventTracker', function() {
  */
 function requireEventTrackerWithHitFilter() {
   ga('require', 'eventTracker', {
-    hitFilter: function(model) {
-      if (model.get('hitType') != 'social') {
+    hitFilter: function(model, element) {
+      if (element.id != 'social-hit-type') {
         throw 'Aborting non-social hits';
       }
       else {

--- a/test/outbound-form-tracker.js
+++ b/test/outbound-form-tracker.js
@@ -313,9 +313,8 @@ function requireOutboundFormTracker_shouldTrackOutboundForm() {
  */
 function requireOutboundFormTracker_hitFilter() {
   ga('require', 'outboundFormTracker', {
-    hitFilter: function(model) {
-      var href = model.get('eventLabel');
-      if (href.indexOf('www.google-analytics.com') > -1) {
+    hitFilter: function(model, form) {
+      if (form.action.indexOf('www.google-analytics.com') > -1) {
         throw 'Exclude hits to www.google-analytics.com';
       }
       else {

--- a/test/outbound-link-tracker.js
+++ b/test/outbound-link-tracker.js
@@ -292,9 +292,8 @@ function requireOutboundLinkTracker_shouldTrackOutboundLink() {
  */
 function requireOutboundLinkTracker_hitFilter() {
   ga('require', 'outboundLinkTracker', {
-    hitFilter: function(model) {
-      var href = model.get('eventLabel');
-      if (href.indexOf('www.google-analytics.com') > -1) {
+    hitFilter: function(model, link) {
+      if (link.href.indexOf('www.google-analytics.com') > -1) {
         throw 'Exclude hits to www.google-analytics.com';
       }
       else {


### PR DESCRIPTION
This PR adds two new features to all plugins that send hits based on interactions with DOM elements:

- The DOM element is passed as the second parameter in the `hitFilter` configuration option (if its set).
- If the DOM element has field attributes (e.g. `ga-event-label`), those fields are automatically included in the hit, and they take precedence over fields specified via the `fieldsObj` configuration option.

This will allow developers to declaratively override field values in hits on a per-element basis. It will also give developers more power to modify/cancel hits conditionally based on the DOM element interacted with.
