### PR TITLE
Fix withTimeout utility function

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -113,13 +113,14 @@ var utilities = {
    */
   withTimeout: function(callback, wait) {
     var called = false;
-    setTimeout(callback, wait || 2000);
-    return function() {
+    function wrappedFunction() {
       if (!called) {
         called = true;
         callback();
       }
-    };
+    }
+    setTimeout(wrappedFunction, wait || 2000);
+    return wrappedFunction
   },
 
 


### PR DESCRIPTION
I noticed a discrepancy between the source here and this same function written in these docs: https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#handling_timeouts

The example in the docs creates a wrapped function that is passed to setTimeout. This source doesn't do that, instead passing `callback` directly to setTimeout, risking potentially calling `callback` twice because the call from setTimeout won't be tracked.

The callback should come into `withTimeout`, and only wrappedFunction should call this callback if it hasn't been called.

If the timeout calls the function, the `called` variable will now get set to true, as it should be