### PR TITLE
Add impressionTracker methods to observe and unobserve elements programmatically

### DIFF
--- a/docs/plugins/clean-url-tracker.md
+++ b/docs/plugins/clean-url-tracker.md
@@ -60,30 +60,30 @@ The following table outlines all possible configuration options for the `cleanUr
     <th align="left">Default</th>
   </tr>
   <tr valign="top">
-    <td><code>stripQuery</code></a></td>
-    <td><code>boolean</code></a></td>
+    <td><code>stripQuery</code></td>
+    <td><code>boolean</code></td>
     <td>
       When <code>true</code>, the query string portion of the URL will be removed.<br>
       <strong>Default:</strong> <code>false</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>queryDimensionIndex</code></a></td>
-    <td><code>number</code></a></td>
+    <td><code>queryDimensionIndex</code></td>
+    <td><code>number</code></td>
     <td>
       There are cases where you want to strip the query string from the URL, but you still want to record what query string was originally there, so you can report on those values separately. You can do this by creating a new <a href="https://support.google.com/analytics/answer/2709829">custom dimension</a> in Google Analytics. Set the dimension's <a href="https://support.google.com/analytics/answer/2709828#example-hit">scope</a> to "hit", and then set the index of the newly created dimension as the <code>queryDimensionIndex</code> option. Once set, the stripped query string will be set on the custom dimension at the specified index.
     </td>
   </tr>
   <tr valign="top">
-    <td><code>indexFilename</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>indexFilename</code></td>
+    <td><code>string</code></td>
     <td>
       When set, the <code>indexFilename</code> value will be stripped from the end of a URL. If your server supports automatically serving index files, you should set this to whatever value your server uses (usually <code>'index.html'</code>).
     </td>
   </tr>
   <tr valign="top">
-    <td><code>trailingSlash</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>trailingSlash</code></td>
+    <td><code>string</code></td>
     <td>
       When set to <code>'add'</code>, a trailing slash is appended to the end of all URLs (if not already present). When set to <code>'remove'</code>, a trailing slash is removed from the end of all URLs. No action is taken if any other value is used. Note: when using the <code>indexFilename</code> option, index filenames are stripped prior to the trailing slash being added or removed.
     </td>
@@ -100,7 +100,7 @@ The following table lists all methods for the `cleanUrlTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>cleanUrlTracker</code> plugin from the specified tracker and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/event-tracker.md
+++ b/docs/plugins/event-tracker.md
@@ -35,29 +35,29 @@ The following table outlines all possible configuration options for the `eventTr
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>events</code></a></td>
-    <td><code>Array</code></a></td>
+    <td><code>events</code></td>
+    <td><code>Array</code></td>
     <td>
       A list of DOM events to listen for. Note that in order for an event set in the HTML via the <code>*-on</code> attribute to work, it must be listed in this array.<br>
       <strong>Default:</strong> <code>['click']</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>attributePrefix</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>attributePrefix</code></td>
+    <td><code>string</code></td>
     <td>
       See the <a href="/docs/common-options.md#attributeprefix">common options guide</a> for the <code>attributePrefix</code> description.<br>
       <strong>Default:</strong> <code>'ga-'</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -73,7 +73,7 @@ The `eventTracker` plugin sets the following default field values on all hits it
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#hitType"><code>hitType</code></a></td>
-    <td><code>'event'</code></a></td>
+    <td><code>'event'</code></td>
   </tr>
 </table>
 
@@ -87,7 +87,7 @@ The following table lists all methods for the `eventTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>eventTracker</code> plugin from the specified tracker, removes all event listeners from the DOM, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/impression-tracker.md
+++ b/docs/plugins/impression-tracker.md
@@ -58,32 +58,32 @@ The following table outlines all possible configuration options for the `impress
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>elements</code></a></td>
-    <td><code>Array&lt;string|Object&gt;</code></a></td>
+    <td><code>elements</code></td>
+    <td><code>Array&lt;string|Object&gt;</code></td>
     <td>
       A list of element IDs or element objects. See the <a href="#element-object-properties"><code>element</code> object properties</a> section below for details.</td>
   </tr>
   <tr valign="top">
-    <td><code>rootMargin</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>rootMargin</code></td>
+    <td><code>string</code></td>
     <td>A CSS margin string accepting pixel or percentage values. It is passed as the <a href="https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver#Properties"><code>rootMargin</code></a> option to the <code>IntersectionObserver</code> instance, which is used to expand or contract the viewport area to change when an element is considered visible. For example: the string <code>'-20px 0'</code> would contract the viewport by 20 pixels on the top and bottom sides, and all element visibility calculations would be based on that rather than the full viewport dimensions.</td>
   </tr>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>attributePrefix</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>attributePrefix</code></td>
+    <td><code>string</code></td>
     <td>
       See the <a href="/docs/common-options.md#attributeprefix">common options guide</a> for the <code>attributePrefix</code> description.<br>
       <strong>Default:</strong> <code>'ga-'</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -97,21 +97,21 @@ The following table outlines all possible configuration options for the `impress
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>id</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>id</code></td>
+    <td><code>string</code></td>
     <td>The ID attribute of the element to track.</td>
   </tr>
   <tr valign="top">
-    <td><code>threshold</code></a></td>
-    <td><code>number</code></a></td>
+    <td><code>threshold</code></td>
+    <td><code>number</code></td>
     <td>
       A percentage of the element's area that must be within the viewport in order for the element to be considered visible. This value is used as one of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver#Properties"><code>thresholds</code></a> passed to the <code>IntersectionObserver</code> instance. A threshold of <code>1</code> means the element must be entirely within the viewport to be considered visible. A threshold of <code>0.5</code> means half of the element must be within the viewport. And a threshold of <code>0</code> means if any of the element intersects with the viewport at all (including just the border), it is considered visible.<br>
       <strong>Default:</strong> <code>0</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>trackFirstImpressionOnly</code></a></td>
-    <td><code>boolean</code></a></td>
+    <td><code>trackFirstImpressionOnly</code></td>
+    <td><code>boolean</code></td>
     <td>
       When <code>true</code>, an impression for this element is only tracked the first time it is visible within the viewport. Set this to <code>false</code> if you want to track subsequent impressions.<br>
       <strong>Default:</strong> <code>true</code>
@@ -135,11 +135,11 @@ The `impressionTracker` plugin sets the following default field values on all hi
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory"><code>eventCategory</code></a></td>
-    <td><code>'Viewport'</code></a></td>
+    <td><code>'Viewport'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventAction"><code>eventAction</code></a></td>
-    <td><code>'impression'</code></a></td>
+    <td><code>'impression'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel"><code>eventLabel</code></a></td>
@@ -159,19 +159,19 @@ The following table lists all methods for the `impressionTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>observeElements</code></a></td>
+    <td><code>observeElements</code></td>
     <td>Accepts an array of <code>elements</code> (as described in the <a href="#options">options</a> section) to start observing for impressions.</td>
   </tr>
   <tr valign="top">
-    <td><code>unobserveElements</code></a></td>
+    <td><code>unobserveElements</code></td>
     <td>Accepts an array of <code>elements</code> (as described in the <a href="#options">options</a> section) to stop observing for impressions. (Note: elements whose <code>trackFirstImpressionOnly</code> property is <code>true</code> are automatically unobserved after the first impression.)</td>
   </tr>
   <tr valign="top">
-    <td><code>unobserveAllElements</code></a></td>
+    <td><code>unobserveAllElements</code></td>
     <td>Stops observing all elements currently being observed.</td>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>impressionTracker</code> plugin from the specified tracker, disconnects all observers, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/impression-tracker.md
+++ b/docs/plugins/impression-tracker.md
@@ -241,7 +241,7 @@ ga('require', 'impressionTracker', {
 
 ### Programmatically observing and unobserving elements
 
-This example requires the `impressionTracker` plugin without specifying any elements to observe. When the user clicks on the `#start-observing` button, observation starts on the `#foo` element. When the user clicks on the #stop-observing` button, observing `#foo` stops.
+This example requires the `impressionTracker` plugin without specifying any elements to observe. When the user clicks on the `#start-observing` button, observation starts on the `#foo` element. When the user clicks on the `#stop-observing` button, observing `#foo` stops.
 
 ```js
 ga('require', 'impressionTracker');

--- a/docs/plugins/impression-tracker.md
+++ b/docs/plugins/impression-tracker.md
@@ -238,3 +238,22 @@ ga('require', 'impressionTracker', {
   rootMargin: '-20px 0'
 });
 ```
+
+### Programmatically observing and unobserving elements
+
+This example requires the `impressionTracker` plugin without specifying any elements to observe. When the user clicks on the `#start-observing` button, observation starts on the `#foo` element. When the user clicks on the #stop-observing` button, observing `#foo` stops.
+
+```js
+ga('require', 'impressionTracker');
+
+var startObservingBtn = document.getElementById('start-observing');
+var stopObservingBtn = document.getElementById('stop-observing');
+
+startObservingBtn.addEventListener('click', function() {
+  ga('impressionTracker:observeElements', ['foo']);
+});
+
+stopObservingBtn.addEventListener('click', function() {
+  ga('impressionTracker:unobserveElements', ['foo']);
+});
+```

--- a/docs/plugins/impression-tracker.md
+++ b/docs/plugins/impression-tracker.md
@@ -164,7 +164,7 @@ The following table lists all methods for the `impressionTracker` plugin:
   </tr>
   <tr valign="top">
     <td><code>unobserveElements</code></a></td>
-    <td>Accepts an array of <code>elements</code> (as described in the <a href="#options">options</a> section) to stop observing for impressions. (Note: elements whose <code>trackFirstImpressionOnly<code> property is <code>true</code> are automatically unobserved after the first impression.)</td>
+    <td>Accepts an array of <code>elements</code> (as described in the <a href="#options">options</a> section) to stop observing for impressions. (Note: elements whose <code>trackFirstImpressionOnly</code> property is <code>true</code> are automatically unobserved after the first impression.)</td>
   </tr>
   <tr valign="top">
     <td><code>unobserveAllElements</code></a></td>

--- a/docs/plugins/impression-tracker.md
+++ b/docs/plugins/impression-tracker.md
@@ -159,6 +159,18 @@ The following table lists all methods for the `impressionTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
+    <td><code>observeElements</code></a></td>
+    <td>Accepts an array of <code>elements</code> (as described in the <a href="#options">options</a> section) to start observing for impressions.</td>
+  </tr>
+  <tr valign="top">
+    <td><code>unobserveElements</code></a></td>
+    <td>Accepts an array of <code>elements</code> (as described in the <a href="#options">options</a> section) to stop observing for impressions. (Note: elements whose <code>trackFirstImpressionOnly<code> property is <code>true</code> are automatically unobserved after the first impression.)</td>
+  </tr>
+  <tr valign="top">
+    <td><code>unobserveAllElements</code></a></td>
+    <td>Stops observing all elements currently being observed.</td>
+  </tr>
+  <tr valign="top">
     <td><code>remove</code></a></td>
     <td>Removes the <code>impressionTracker</code> plugin from the specified tracker, disconnects all observers, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>

--- a/docs/plugins/media-query-tracker.md
+++ b/docs/plugins/media-query-tracker.md
@@ -37,13 +37,13 @@ The following table outlines all possible configuration options for the `mediaQu
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>definitions</code></a></td>
-    <td><code>Object|Array&lt;Object&gt;</code></a></td>
+    <td><code>definitions</code></td>
+    <td><code>Object|Array&lt;Object&gt;</code></td>
     <td>A <code>definition</code> object or an array of <code>definition</code> objects. See the <a href="#the-definition-object"><code>definition</code></a> object description for property details.</td>
   </tr>
   <tr valign="top">
-    <td><code>changeTemplate</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>changeTemplate</code></td>
+    <td><code>Function</code></td>
     <td colspan="2">
     The <code>changeTemplate</code> function (via its return value) determines what the <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel"><code>eventLabel</code></a> field will be for event hits when the matching media definition changes. The function is invoked with the newly matching value and the previously matching value as its first and second arguments, respectively:<br>
     <strong>Default:</strong>
@@ -53,20 +53,20 @@ The following table outlines all possible configuration options for the `mediaQu
     </td>
   </tr>
   <tr valign="top">
-    <td><code>changeTimeout</code></a></td>
-    <td><code>number</code></a></td>
+    <td><code>changeTimeout</code></td>
+    <td><code>number</code></td>
     <td>The debounce timeout, i.e., the amount of time to wait before sending the change event. If multiple change events occur within the timeout period, only the last one is sent.<br>
     <strong>Default:</strong> <code>1000</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -82,18 +82,18 @@ The `definition` object allows you to group multiple different types of media qu
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>name</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>name</code></td>
+    <td><code>string</code></td>
     <td>A unique name that will be used as the <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory"><code>eventCategory</code></a> value for media query change events.</td>
   </tr>
   <tr valign="top">
-    <td><code>dimensionIndex</code></a></td>
-    <td><code>number</code></a></td>
+    <td><code>dimensionIndex</code></td>
+    <td><code>number</code></td>
     <td>The index of the custom dimension <a href="https://support.google.com/analytics/answer/2709829">created in Google Analytics</a>.</td>
   </tr>
   <tr valign="top">
-    <td><code>items</code></a></td>
-    <td><code>Array</code></a></td>
+    <td><code>items</code></td>
+    <td><code>Array</code></td>
     <td>An array of <code>item</code> objects. See the <a href="#the-item-object"><code>item</code></a> object description for property details.</td>
   </tr>
 </table>
@@ -109,13 +109,13 @@ The `item` object allows you to specify what media query values are relevant wit
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>name</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>name</code></td>
+    <td><code>string</code></td>
     <td>The value that will be set on the custom dimension at the specified index.</td>
   </tr>
   <tr valign="top">
-    <td><code>media</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>media</code></td>
+    <td><code>string</code></td>
     <td>The media query value to test for a match.</td>
   </tr>
 </table>
@@ -137,11 +137,11 @@ The `mediaQueryTracker` plugin sets the following default field values on all hi
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory"><code>eventCategory</code></a></td>
-    <td><code>definition.name</code></a></td>
+    <td><code>definition.name</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventAction"><code>eventAction</code></a></td>
-    <td><code>'change'</code></a></td>
+    <td><code>'change'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel"><code>eventLabel</code></a></td>
@@ -161,7 +161,7 @@ The following table lists all methods for the `mediaQueryTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>mediaQueryTracker</code> plugin from the specified tracker, removes all media query listeners, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/outbound-form-tracker.md
+++ b/docs/plugins/outbound-form-tracker.md
@@ -33,16 +33,16 @@ The following table outlines all possible configuration options for the `outboun
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>formSelector</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>formSelector</code></td>
+    <td><code>string</code></td>
     <td>
       A selector used to identify forms to listen for submit events on.<br>
       <strong>Default:</strong> <code>'form'</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>shouldTrackOutboundForm</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>shouldTrackOutboundForm</code></td>
+    <td><code>Function</code></td>
     <td>
       A function that returns <code>true</code> if the form in question should be considered an outbound form. The function is invoked with the form element as its first argument and a <code>parseUrl</code> utility function (which returns a <a href="https://developer.mozilla.org/en-US/docs/Web/API/Location"><code>Location</code></a>-like object) as its second argument.<br>
       <strong>Default:</strong>
@@ -54,21 +54,21 @@ The following table outlines all possible configuration options for the `outboun
     </td>
   </tr>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>attributePrefix</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>attributePrefix</code></td>
+    <td><code>string</code></td>
     <td>
       See the <a href="/docs/common-options.md#attributeprefix">common options guide</a> for the <code>attributePrefix</code> description.<br>
       <strong>Default:</strong> <code>'ga-'</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -88,11 +88,11 @@ The `outboundFormTracker` plugin sends hits with the following values. To custom
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory"><code>eventCategory</code></a></td>
-    <td><code>'Outbound Form'</code></a></td>
+    <td><code>'Outbound Form'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventAction"><code>eventAction</code></a></td>
-    <td><code>'submit'</code></a></td>
+    <td><code>'submit'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel"><code>eventLabel</code></a></td>
@@ -112,7 +112,7 @@ The following table lists all methods for the `outboundFormTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>outboundFormTracker</code> plugin from the specified tracker, removes all event listeners from the DOM, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/outbound-link-tracker.md
+++ b/docs/plugins/outbound-link-tracker.md
@@ -33,24 +33,24 @@ The following table outlines all possible configuration options for the `outboun
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>events</code></a></td>
-    <td><code>Array</code></a></td>
+    <td><code>events</code></td>
+    <td><code>Array</code></td>
     <td>
       A list of events to listen for on links. Since it's possible to navigate to a link without generating a <code>click</code> (e.g. right-clicking generates a <code>contextmenu</code> event), you can customize this option to track additional events.<br>
       <strong>Default:</strong> <code>['click']</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>linkSelector</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>linkSelector</code></td>
+    <td><code>string</code></td>
     <td>
       A selector used to identify links to listen for events on.<br>
       <strong>Default:</strong> <code>'a, area'</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>shouldTrackOutboundLink</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>shouldTrackOutboundLink</code></td>
+    <td><code>Function</code></td>
     <td>
       A function that returns <code>true</code> if the link in question should be considered an outbound link. The function is invoked with the link element as its first argument and a <code>parseUrl</code> utility function (which returns a <a href="https://developer.mozilla.org/en-US/docs/Web/API/Location"><code>Location</code></a>-like object) as its second argument.<br>
       <strong>Default:</strong>
@@ -63,21 +63,21 @@ The following table outlines all possible configuration options for the `outboun
     </td>
   </tr>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>attributePrefix</code></a></td>
-    <td><code>string</code></a></td>
+    <td><code>attributePrefix</code></td>
+    <td><code>string</code></td>
     <td>
       See the <a href="/docs/common-options.md#attributeprefix">common options guide</a> for the <code>attributePrefix</code> description.<br>
       <strong>Default:</strong> <code>'ga-'</code>
     </td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -97,11 +97,11 @@ The `outboundLinkTracker` plugin sends hits with the following values. To custom
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory"><code>eventCategory</code></a></td>
-    <td><code>'Outbound Link'</code></a></td>
+    <td><code>'Outbound Link'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventAction"><code>eventAction</code></a></td>
-    <td><code>event.type</code></a></td>
+    <td><code>event.type</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel"><code>eventLabel</code></a></td>
@@ -121,7 +121,7 @@ The following table lists all methods for the `outboundLinkTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>outboundLinkTracker</code> plugin from the specified tracker, removes all event listeners from the DOM, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/page-visibility-tracker.md
+++ b/docs/plugins/page-visibility-tracker.md
@@ -37,16 +37,16 @@ The following table outlines all possible configuration options for the `pageVis
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>sessionTimeout</code></a></td>
-    <td><code>number</code></a></td>
+    <td><code>sessionTimeout</code></td>
+    <td><code>number</code></td>
     <td>
       The <a href="https://support.google.com/analytics/answer/2795871">session timeout</a> amount (in minutes) of the Google Analytics property. By default this value is 30 minutes, which is the same default used for new Google Analytics properties. The value set for this plugin should always be the same as the property setting in Google Analytics.<br>
       <strong>Default:</strong> <code>30</code>
   </td>
   </tr>
   <tr valign="top">
-    <td><code>changeTemplate</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>changeTemplate</code></td>
+    <td><code>Function</code></td>
     <td>
       A function that accepts the old and new values and returns a string to be used as the <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel"><code>eventLabel</code></a> field for change events.<br>
       <strong>Default:</strong>
@@ -56,23 +56,23 @@ The following table outlines all possible configuration options for the `pageVis
     </td>
   </tr>
   <tr valign="top">
-    <td><code>hiddenMetricIndex</code></a></td>
-    <td><code>number</code></a></td>
+    <td><code>hiddenMetricIndex</code></td>
+    <td><code>number</code></td>
     <td>If set, a <a href="https://support.google.com/analytics/answer/2709828">custom metric</a> at the index provided is sent when the page's visibility state changes from hidden to visible. The metric value is the amount of time (in seconds) the page was in the hidden state.</td>
   </tr>
   <tr valign="top">
-    <td><code>visibleMetricIndex</code></a></td>
-    <td><code>number</code></a></td>
+    <td><code>visibleMetricIndex</code></td>
+    <td><code>number</code></td>
     <td>If set, a <a href="https://support.google.com/analytics/answer/2709828">custom metric</a> at the index provided is sent when the page's visibility state changes from visible to hidden. The metric value is the amount of time (in seconds) the page was in the visible state.</td>
   </tr>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -94,11 +94,11 @@ The `pageVisibilityTracker` plugin sets the following default field values on ev
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory"><code>eventCategory</code></a></td>
-    <td><code>'Page Visibility'</code></a></td>
+    <td><code>'Page Visibility'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventAction"><code>eventAction</code></a></td>
-    <td><code>'change'</code></a></td>
+    <td><code>'change'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel"><code>eventLabel</code></a></td>
@@ -154,7 +154,7 @@ The following table lists all methods for the `pageVisibilityTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>pageVisibilityTracker</code> plugin from the specified tracker, removes all event listeners from the DOM, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/social-widget-tracker.md
+++ b/docs/plugins/social-widget-tracker.md
@@ -25,13 +25,13 @@ The following table outlines all possible configuration options for the `socialW
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -53,7 +53,7 @@ The `socialWidgetTracker` plugin sets the following default field values on all 
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#socialNetwork"><code>socialNetwork</code></a></td>
-    <td><code>'Facebook'</code></a></td>
+    <td><code>'Facebook'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#socialAction"><code>socialAction</code></a></td>
@@ -78,7 +78,7 @@ The `socialWidgetTracker` plugin sets the following default field values on all 
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#socialNetwork"><code>socialNetwork</code></a></td>
-    <td><code>'Twitter'</code></a></td>
+    <td><code>'Twitter'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#socialAction"><code>socialAction</code></a></td>
@@ -103,7 +103,7 @@ The `socialWidgetTracker` plugin sets the following default field values on all 
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#socialNetwork"><code>socialNetwork</code></a></td>
-    <td><code>'Twitter'</code></a></td>
+    <td><code>'Twitter'</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#socialAction"><code>socialAction</code></a></td>
@@ -125,7 +125,7 @@ The following table lists all methods for the `socialWidgetTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>socialWidgetTracker</code> plugin from the specified tracker, removes all event listeners registered with the social SDKs, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/docs/plugins/url-change-tracker.md
+++ b/docs/plugins/url-change-tracker.md
@@ -29,8 +29,8 @@ The following table outlines all possible configuration options for the `urlChan
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>shouldTrackUrlChange</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>shouldTrackUrlChange</code></td>
+    <td><code>Function</code></td>
     <td>
       A function used to determine if a URL change should be tracked. The function is invoked with the string values <code>newPath</code> and <code>oldPath</code> which represent the pathname and search portion of the URL (not the hash portion). Note, the function is only invoked if the new path and old path are different.<br>
       <strong>Default:</strong>
@@ -39,13 +39,13 @@ The following table outlines all possible configuration options for the `urlChan
 };</pre>
     </td>
   <tr valign="top">
-    <td><code>fieldsObj</code></a></td>
-    <td><code>Object</code></a></td>
+    <td><code>fieldsObj</code></td>
+    <td><code>Object</code></td>
     <td>See the <a href="/docs/common-options.md#fieldsobj">common options guide</a> for the <code>fieldsObj</code> description.</td>
   </tr>
   <tr valign="top">
-    <td><code>hitFilter</code></a></td>
-    <td><code>Function</code></a></td>
+    <td><code>hitFilter</code></td>
+    <td><code>Function</code></td>
     <td>See the <a href="/docs/common-options.md#hitfilter">common options guide</a> for the <code>hitFilter</code> description.</td>
   </tr>
 </table>
@@ -65,11 +65,11 @@ The `urlChangeTracker` plugin sets the following default field values on all hit
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#page"><code>page</code></a></td>
-    <td><code>newPath</code></a></td>
+    <td><code>newPath</code></td>
   </tr>
   <tr valign="top">
     <td><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#title"><code>title</code></a></td>
-    <td><code>document.title</code></a></td>
+    <td><code>document.title</code></td>
   </tr>
 </table>
 
@@ -85,7 +85,7 @@ The following table lists all methods for the `urlChangeTracker` plugin:
     <th align="left">Description</th>
   </tr>
   <tr valign="top">
-    <td><code>remove</code></a></td>
+    <td><code>remove</code></td>
     <td>Removes the <code>urlChangeTracker</code> plugin from the specified tracker, removes all event listeners from the DOM, and restores all modified tasks to their original state prior to the plugin being required.</td>
   </tr>
 </table>

--- a/lib/plugins/impression-tracker.js
+++ b/lib/plugins/impression-tracker.js
@@ -68,12 +68,12 @@ function ImpressionTracker(tracker, opts) {
 
   // Once the DOM is ready, start observing for changes.
   domReady(function() {
-    this.addElements(this.opts.elements);
+    this.observeElements(this.opts.elements);
   }.bind(this));
 }
 
 
-ImpressionTracker.prototype.addElements = function(elements) {
+ImpressionTracker.prototype.observeElements = function(elements) {
   var data = this.deriveDataFromElements(elements);
 
   // Merge the new data with the data already on the plugin instance.
@@ -113,7 +113,7 @@ ImpressionTracker.prototype.addElements = function(elements) {
 };
 
 
-ImpressionTracker.prototype.removeElements = function(elements) {
+ImpressionTracker.prototype.unobserveElements = function(elements) {
   var itemsToKeep = [];
   var itemsToRemove = [];
 
@@ -133,9 +133,9 @@ ImpressionTracker.prototype.removeElements = function(elements) {
   });
 
   // If there are no items to keep, exit early by running the
-  // `removeAllElements` logic.
+  // `unobserveAllElements` logic.
   if (!itemsToKeep.length) {
-    return this.removeAllElements();
+    return this.unobserveAllElements();
   }
 
   var dataToKeep = this.deriveDataFromElements(itemsToKeep);
@@ -164,7 +164,7 @@ ImpressionTracker.prototype.removeElements = function(elements) {
 };
 
 
-ImpressionTracker.prototype.removeAllElements = function() {
+ImpressionTracker.prototype.unobserveAllElements = function() {
   Object.keys(this.thresholdMap).forEach(function(key) {
     this.thresholdMap[key].disconnect();
   }.bind(this));
@@ -280,7 +280,7 @@ ImpressionTracker.prototype.handleIntersectionChanges = function(records) {
     }
   }
   if (itemsToRemove.length) {
-    this.removeElements(itemsToRemove);
+    this.unobserveElements(itemsToRemove);
   }
 };
 
@@ -342,7 +342,7 @@ ImpressionTracker.prototype.handleDomElementRemoved = function(id) {
  * Removes all listeners and observers.
  */
 ImpressionTracker.prototype.remove = function() {
-  this.removeAllElements();
+  this.unobserveAllElements();
 };
 
 

--- a/lib/plugins/impression-tracker.js
+++ b/lib/plugins/impression-tracker.js
@@ -37,7 +37,7 @@ function ImpressionTracker(tracker, opts) {
   if (!(window.IntersectionObserver && window.MutationObserver)) return;
 
   this.opts = assign({
-    elements: [],
+    elements: null,
     rootMargin: '0px',
     fieldsObj: {},
     attributePrefix: 'ga-',
@@ -48,107 +48,172 @@ function ImpressionTracker(tracker, opts) {
 
   // Binds methods.
   this.handleDomMutations = this.handleDomMutations.bind(this);
-  this.walkNodeTree = this.walkNodeTree.bind(this);
   this.handleIntersectionChanges = this.handleIntersectionChanges.bind(this);
-  this.startObserving = this.startObserving.bind(this);
   this.observeElement = this.observeElement.bind(this);
   this.handleDomElementRemoved = this.handleDomElementRemoved.bind(this);
 
-  var data = this.deriveDataFromConfigOptions();
-
   // The primary list of elements to observe. Each item contains the
   // element ID, threshold, and whether it's currently in-view.
-  this.items = data.items;
-
-  // A hash map of elements contained in the items array.
-  this.elementMap = data.elementMap;
-
-  // A sorted list of threshold values contained in the items array.
-  this.threshold = data.threshold;
-
-  this.intersectionObserver = this.initIntersectionObserver();
-  this.mutationObserver = this.initMutationObserver();
-
-  // Once the DOM is ready, start observing for changes.
-  domReady(this.startObserving);
-}
-
-
-/**
- * Loops through each element in the `elements` configuration option and
- * creates a map of element IDs currently being observed, a list of "items"
- * (which contains each element's `threshold` and `trackFirstImpressionOnly`
- * property), and a list of `threshold` values to pass to the
- * `IntersectionObserver` instance.
- * @return {Object} An object with the properties `items`, `elementMap`
- *     and `threshold`.
- */
-ImpressionTracker.prototype.deriveDataFromConfigOptions = function() {
-  var items = [];
-  var threshold = [];
+  this.items = [];
 
   // A map of element IDs in the `items` array to DOM elements in the document.
   // The presence of a key indicates that the element ID is in the `items`
   // array, and the presence of an element value indicates that the element
   // is in the DOM.
+  this.elementMap = {};
+
+  // A map of threshold values. The presense of a key indicates that the
+  // threshold value is registered on the current IntersectionObserver instance.
+  this.thresholdMap = {};
+
+  // Once the DOM is ready, start observing for changes.
+  domReady(function() {
+    this.addElements(this.opts.elements);
+  }.bind(this));
+}
+
+
+ImpressionTracker.prototype.addElements = function(elements) {
+  var data = this.deriveDataFromElements(elements);
+  var originalThresholdMap = this.thresholdMap;
+
+  this.items = this.items.concat(data.items);
+  this.elementMap = assign({}, data.elementMap, this.elementMap);
+  this.thresholdMap = assign({}, data.thresholdMap, this.thresholdMap);
+
+  var elementsIncludeNewThreshold = Object.keys(data.thresholdMap)
+      .some(function(threshold) {
+        return !originalThresholdMap[threshold];
+      });
+
+  // If any of the elements contain a threshold value that wasn't instantiated
+  // on the IntersectionObserver instance, there's no way to observe without
+  // creating a new instance altogether.
+  if (elementsIncludeNewThreshold && this.intersectionObserver) {
+    this.intersectionObserver.disconnect();
+    this.intersectionObserver = null;
+  }
+
+  this.observeElements();
+};
+
+
+ImpressionTracker.prototype.removeElements = function(elements) {
+  var itemsToKeep = [];
+  var itemsToRemove = [];
+
+  this.items.forEach(function(item) {
+    var itemInItems = elements.some(function(element) {
+      var itemToRemove = getItemFromElement(element);
+      return itemToRemove.id === item.id &&
+          itemToRemove.threshold === item.threshold &&
+          itemToRemove.trackFirstImpressionOnly ===
+              item.trackFirstImpressionOnly;
+    });
+    if (itemInItems) {
+      itemsToRemove.push(item);
+    } else {
+      itemsToKeep.push(item);
+    }
+  });
+
+  // If there are no items to keep, exit early by running the
+  // `removeAllElements` logic.
+  if (!itemsToKeep.length) {
+    return this.removeAllElements();
+  }
+
+  var dataToKeep = this.deriveDataFromElements(itemsToKeep);
+  var dataToRemove = this.deriveDataFromElements(itemsToRemove);
+
+  this.items = dataToKeep.items;
+  this.elementMap = assign({}, dataToKeep.elementMap, this.elementMap);
+  this.thresholdMap = assign({}, dataToKeep.thresholdMap, this.thresholdMap);
+
+  var thresholdNeedsRemoval = Object.keys(dataToRemove.thresholdMap)
+      .some(function(threshold) {
+        return !dataToKeep.thresholdMap[threshold];
+      });
+
+  if (thresholdNeedsRemoval) {
+    this.intersectionObserver.disconnect();
+    this.intersectionObserver = null;
+    this.observeElements();
+  } else {
+    Object.keys(dataToRemove.items).forEach(function(item) {
+      if (dataToKeep.elementMap[item.id]) this.unobserveElement(item.id);
+    }.bind(this));
+  }
+};
+
+
+ImpressionTracker.prototype.removeAllElements = function() {
+  this.intersectionObserver.disconnect();
+  this.intersectionObserver = null;
+  this.mutationObserver.disconnect();
+  this.mutationObserver = null;
+
+  this.items = [];
+  this.elementMap = {};
+  this.thresholdMap = {};
+};
+
+
+/**
+ * Loops through each of the passed elements and creates a map of element IDs,
+ * threshold values, and a list of "items" (which contains each element's
+ * `threshold` and `trackFirstImpressionOnly` property).
+ * @param {Array} elements A list of elements to derive item data from.
+ * @return {Object} An object with the properties `items`, `elementMap`
+ *     and `threshold`.
+ */
+ImpressionTracker.prototype.deriveDataFromElements = function(elements) {
+  var items = [];
+  var thresholdMap = {};
   var elementMap = {};
 
-  this.opts.elements.forEach(function(item) {
-    // The item can be just a string if it's OK with all the defaults.
-    if (typeof item == 'string') item = {id: item};
+  if (elements.length) {
+    elements.forEach(function(element) {
+      var item = getItemFromElement(element);
 
-    items.push(item = assign({
-      threshold: 0,
-      trackFirstImpressionOnly: true
-    }, item));
-
-    elementMap[item.id] = null;
-    threshold.push(item.threshold);
-  });
+      items.push(item);
+      elementMap[item.id] = null;
+      thresholdMap[item.threshold] = true;
+    });
+  }
 
   return {
     items: items,
     elementMap: elementMap,
-    threshold: threshold
+    thresholdMap: thresholdMap
   };
 };
 
 
 /**
- * Initializes a new `MutationObsever` instance and registers the callback.
- * @return {MutationObserver} The new MutationObserver instance.
+ * Starts observing each element for intersections.
  */
-ImpressionTracker.prototype.initMutationObserver = function() {
-  return new MutationObserver(this.handleDomMutations);
-};
+// ImpressionTracker.prototype.startObservingIntersections = function() {
+ImpressionTracker.prototype.observeElements = function() {
+  if (!this.intersectionObserver) {
+    // this.intersectionObserver = this.initIntersectionObserver();
+    var threshold = Object.keys(this.thresholdMap).map(Number);
+    this.intersectionObserver =
+        new IntersectionObserver(this.handleIntersectionChanges, {
+      rootMargin: this.opts.rootMargin,
+      threshold: threshold
+    });
+  }
+  if (!this.mutationObserver) {
+    this.mutationObserver = new MutationObserver(this.handleDomMutations);
+    this.mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  }
 
-
-/**
- * Initializes a new `IntersectionObsever` instance with the appropriate
- * options and registers the callback.
- * @return {IntersectionObserver} The newly created instance.
- */
-ImpressionTracker.prototype.initIntersectionObserver = function() {
-  return new IntersectionObserver(this.handleIntersectionChanges, {
-    rootMargin: this.opts.rootMargin,
-    threshold: this.threshold
-  });
-};
-
-
-/**
- * Starts observing each eleemnt to intersections as well as the entire DOM
- * for node changes.
- */
-ImpressionTracker.prototype.startObserving = function() {
   // Start observing elements for intersections.
   Object.keys(this.elementMap).forEach(this.observeElement);
-
-  // Start observing the DOM for added and removed elements.
-  this.mutationObserver.observe(document.body, {
-    childList: true,
-    subtree: true
-  });
 
   // TODO(philipwalton): Remove temporary hack to force a new frame
   // immediately after adding observers.
@@ -219,16 +284,11 @@ ImpressionTracker.prototype.handleIntersectionChanges = function(records) {
         this.handleImpression(item.id);
 
         if (item.trackFirstImpressionOnly) {
-          this.items.splice(j, 1);
-          j--;
-          this.possiblyUnobserveElement(item.id);
+          this.removeElements([item]);
         }
       }
     }
   }
-
-  // If all items have been removed, remove the plugin.
-  if (this.items.length === 0) this.remove();
 };
 
 
@@ -254,17 +314,9 @@ ImpressionTracker.prototype.handleImpression = function(id) {
 };
 
 
-/**
- * Inspects the `items` array after an item was removed. If the removed
- * item's element ID is not found in any other item, the element stops being
- * observed for intersection changes and is removed from `elementMap`.
- * @param {string} id The element ID to check for possible unobservation.
- */
-ImpressionTracker.prototype.possiblyUnobserveElement = function(id) {
-  if (!this.itemsIncludesId(id)) {
-    this.intersectionObserver.unobserve(this.elementMap[id]);
-    delete this.elementMap[id];
-  }
+ImpressionTracker.prototype.unobserveElement = function(id) {
+  this.intersectionObserver.unobserve(this.elementMap[id]);
+  delete this.elementMap[id];
 };
 
 
@@ -280,23 +332,10 @@ ImpressionTracker.prototype.handleDomElementRemoved = function(id) {
 
 
 /**
- * Scans the `items` array for the presense of an item with the passed ID.
- * @param {string} id The ID of the element to search for.
- * @return {boolean} True if the element ID was found in one of the items.
- */
-ImpressionTracker.prototype.itemsIncludesId = function(id) {
-  return this.items.some(function(item) {
-    return id == item.id;
-  });
-};
-
-
-/**
  * Removes all listeners and observers.
  */
 ImpressionTracker.prototype.remove = function() {
-  this.mutationObserver.disconnect();
-  this.intersectionObserver.disconnect();
+  this.removeAllElements();
 };
 
 
@@ -319,3 +358,18 @@ function isTargetVisible(threshold, record) {
     return record.intersectionRatio >= threshold;
   }
 }
+
+/**
+ * Creates an item by merging the passed element with the item defaults.
+ * If the passed element is just a string, that string is treated as
+ * the item ID.
+ * @param {Object|string} element The element to convert to an item.
+ * @return {Object} The item object.
+ */
+function getItemFromElement(element) {
+  return assign({threshold: 0, trackFirstImpressionOnly: true},
+      typeof element == 'string' ? {id: element} : element);
+
+}
+
+

--- a/lib/plugins/impression-tracker.js
+++ b/lib/plugins/impression-tracker.js
@@ -209,8 +209,6 @@ ImpressionTracker.prototype.deriveDataFromElements = function(elements) {
 };
 
 
-
-
 /**
  * Adds an element to the `elementMap` map and registers it for observation
  * on `this.intersectionObserver`.

--- a/lib/plugins/impression-tracker.js
+++ b/lib/plugins/impression-tracker.js
@@ -49,7 +49,7 @@ function ImpressionTracker(tracker, opts) {
   // Binds methods.
   this.handleDomMutations = this.handleDomMutations.bind(this);
   this.handleIntersectionChanges = this.handleIntersectionChanges.bind(this);
-  this.observeElement = this.observeElement.bind(this);
+  this.handleDomElementAdded = this.handleDomElementAdded.bind(this);
   this.handleDomElementRemoved = this.handleDomElementRemoved.bind(this);
 
   // The primary list of elements to observe. Each item contains the
@@ -62,8 +62,8 @@ function ImpressionTracker(tracker, opts) {
   // is in the DOM.
   this.elementMap = {};
 
-  // A map of threshold values. The presense of a key indicates that the
-  // threshold value is registered on the current IntersectionObserver instance.
+  // A map of threshold values. Each threshold is mapped to an
+  // IntersectionObserver instance specific to that threshold.
   this.thresholdMap = {};
 
   // Once the DOM is ready, start observing for changes.
@@ -75,26 +75,41 @@ function ImpressionTracker(tracker, opts) {
 
 ImpressionTracker.prototype.addElements = function(elements) {
   var data = this.deriveDataFromElements(elements);
-  var originalThresholdMap = this.thresholdMap;
 
+  // Merge the new data with the data already on the plugin instance.
   this.items = this.items.concat(data.items);
   this.elementMap = assign({}, data.elementMap, this.elementMap);
   this.thresholdMap = assign({}, data.thresholdMap, this.thresholdMap);
 
-  var elementsIncludeNewThreshold = Object.keys(data.thresholdMap)
-      .some(function(threshold) {
-        return !originalThresholdMap[threshold];
-      });
+  // Observe each new item.
+  data.items.forEach(function(item) {
+    var observer = this.thresholdMap[item.threshold] =
+        (this.thresholdMap[item.threshold] || new IntersectionObserver(
+            this.handleIntersectionChanges, {
+              rootMargin: this.opts.rootMargin,
+              threshold: [+item.threshold]
+            }));
 
-  // If any of the elements contain a threshold value that wasn't instantiated
-  // on the IntersectionObserver instance, there's no way to observe without
-  // creating a new instance altogether.
-  if (elementsIncludeNewThreshold && this.intersectionObserver) {
-    this.intersectionObserver.disconnect();
-    this.intersectionObserver = null;
+    var element = this.elementMap[item.id] ||
+        (this.elementMap[item.id] = document.getElementById(item.id));
+
+    if (element) {
+      observer.observe(element);
+    }
+  }.bind(this));
+
+  if (!this.mutationObserver) {
+    this.mutationObserver = new MutationObserver(this.handleDomMutations);
+    this.mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
   }
 
-  this.observeElements();
+  // TODO(philipwalton): Remove temporary hack to force a new frame
+  // immediately after adding observers.
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=612323
+  requestAnimationFrame(function() {});
 };
 
 
@@ -127,29 +142,33 @@ ImpressionTracker.prototype.removeElements = function(elements) {
   var dataToRemove = this.deriveDataFromElements(itemsToRemove);
 
   this.items = dataToKeep.items;
-  this.elementMap = assign({}, dataToKeep.elementMap, this.elementMap);
-  this.thresholdMap = assign({}, dataToKeep.thresholdMap, this.thresholdMap);
+  this.elementMap = dataToKeep.elementMap;
+  this.thresholdMap = dataToKeep.thresholdMap;
 
-  var thresholdNeedsRemoval = Object.keys(dataToRemove.thresholdMap)
-      .some(function(threshold) {
-        return !dataToKeep.thresholdMap[threshold];
-      });
+  // Unobserve removed elements.
+  itemsToRemove.forEach(function(item) {
+    if (!dataToKeep.elementMap[item.id]) {
+      var observer = dataToRemove.thresholdMap[item.threshold];
+      var element = dataToRemove.elementMap[item.id];
 
-  if (thresholdNeedsRemoval) {
-    this.intersectionObserver.disconnect();
-    this.intersectionObserver = null;
-    this.observeElements();
-  } else {
-    Object.keys(dataToRemove.items).forEach(function(item) {
-      if (dataToKeep.elementMap[item.id]) this.unobserveElement(item.id);
-    }.bind(this));
-  }
+      if (element) {
+        observer.unobserve(element);
+      }
+
+      // Disconnect unneeded threshold observers.
+      if (!dataToKeep.thresholdMap[item.threshold]) {
+        dataToRemove.thresholdMap[item.threshold].disconnect();
+      }
+    }
+  });
 };
 
 
 ImpressionTracker.prototype.removeAllElements = function() {
-  this.intersectionObserver.disconnect();
-  this.intersectionObserver = null;
+  Object.keys(this.thresholdMap).forEach(function(key) {
+    this.thresholdMap[key].disconnect();
+  }.bind(this));
+
   this.mutationObserver.disconnect();
   this.mutationObserver = null;
 
@@ -177,9 +196,9 @@ ImpressionTracker.prototype.deriveDataFromElements = function(elements) {
       var item = getItemFromElement(element);
 
       items.push(item);
-      elementMap[item.id] = null;
-      thresholdMap[item.threshold] = true;
-    });
+      elementMap[item.id] = this.elementMap[item.id] || null;
+      thresholdMap[item.threshold] = this.thresholdMap[item.threshold] || null;
+    }.bind(this));
   }
 
   return {
@@ -190,36 +209,6 @@ ImpressionTracker.prototype.deriveDataFromElements = function(elements) {
 };
 
 
-/**
- * Starts observing each element for intersections.
- */
-// ImpressionTracker.prototype.startObservingIntersections = function() {
-ImpressionTracker.prototype.observeElements = function() {
-  if (!this.intersectionObserver) {
-    // this.intersectionObserver = this.initIntersectionObserver();
-    var threshold = Object.keys(this.thresholdMap).map(Number);
-    this.intersectionObserver =
-        new IntersectionObserver(this.handleIntersectionChanges, {
-      rootMargin: this.opts.rootMargin,
-      threshold: threshold
-    });
-  }
-  if (!this.mutationObserver) {
-    this.mutationObserver = new MutationObserver(this.handleDomMutations);
-    this.mutationObserver.observe(document.body, {
-      childList: true,
-      subtree: true
-    });
-  }
-
-  // Start observing elements for intersections.
-  Object.keys(this.elementMap).forEach(this.observeElement);
-
-  // TODO(philipwalton): Remove temporary hack to force a new frame
-  // immediately after adding observers.
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=612323
-  requestAnimationFrame(function() {});
-};
 
 
 /**
@@ -248,7 +237,7 @@ ImpressionTracker.prototype.handleDomMutations = function(mutations) {
     }
     // Handles added elements.
     for (var j = 0, addedEl; addedEl = mutation.addedNodes[j]; j++) {
-      this.walkNodeTree(addedEl, this.observeElement);
+      this.walkNodeTree(addedEl, this.handleDomElementAdded);
     }
   }
 };
@@ -276,6 +265,7 @@ ImpressionTracker.prototype.walkNodeTree = function(node, callback) {
  * @param {Array} records A list of `IntersectionObserverEntry` records.
  */
 ImpressionTracker.prototype.handleIntersectionChanges = function(records) {
+  var itemsToRemove = [];
   for (var i = 0, record; record = records[i]; i++) {
     for (var j = 0, item; item = this.items[j]; j++) {
       if (record.target.id !== item.id) continue;
@@ -284,10 +274,13 @@ ImpressionTracker.prototype.handleIntersectionChanges = function(records) {
         this.handleImpression(item.id);
 
         if (item.trackFirstImpressionOnly) {
-          this.removeElements([item]);
+          itemsToRemove.push(item);
         }
       }
     }
+  }
+  if (itemsToRemove.length) {
+    this.removeElements(itemsToRemove);
   }
 };
 
@@ -314,9 +307,17 @@ ImpressionTracker.prototype.handleImpression = function(id) {
 };
 
 
-ImpressionTracker.prototype.unobserveElement = function(id) {
-  this.intersectionObserver.unobserve(this.elementMap[id]);
-  delete this.elementMap[id];
+/**
+ * Handles an element in the items array being added to the DOM.
+ * @param {string} id The ID of the element that was added.
+ */
+ImpressionTracker.prototype.handleDomElementAdded = function(id) {
+  var element = this.elementMap[id] = document.getElementById(id);
+  this.items.forEach(function(item) {
+    if (id == item.id) {
+      this.thresholdMap[item.threshold].observe(element);
+    }
+  }.bind(this));
 };
 
 
@@ -326,7 +327,13 @@ ImpressionTracker.prototype.unobserveElement = function(id) {
  * @param {string} id The ID of the element that was removed.
  */
 ImpressionTracker.prototype.handleDomElementRemoved = function(id) {
-  this.intersectionObserver.unobserve(this.elementMap[id]);
+  var element = this.elementMap[id];
+  this.items.forEach(function(item) {
+    if (id == item.id) {
+      this.thresholdMap[item.threshold].unobserve(element);
+    }
+  }.bind(this));
+
   this.elementMap[id] = null;
 };
 

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -61,11 +61,14 @@ module.exports =  {
     });
   },
 
-  hitDataMatches: function(expected) {
+  hitDataMatches: function(expected, compareFunction) {
     return function() {
-      var hitData = browser.execute(this.getHitData);
+      var hitData = browser.execute(this.getHitData).value;
+      if (compareFunction) {
+        hitData = hitData.sort(compareFunction);
+      }
       return expected.every(function(item) {
-        return get(hitData.value, item[0]) === item[1];
+        return get(hitData, item[0]) === item[1];
       });
     }.bind(this);
   },

--- a/test/impression-tracker.html
+++ b/test/impression-tracker.html
@@ -6,32 +6,7 @@
   </script>
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!--
-  // Loads autotrack sync so the following bug-fixing logic can be run
-  // prior to analytics.js loading the impressionTracker plugin.
-  -->
-  <script src="/autotrack.js"></script>
-  <script>
-  // Fixes the records ordering of the IntersectionObserver callback.
-  // This is nessary to do here until https://crbug.com/613679 is live.
-  var originalHandleIntersectionChanges =
-      gaplugins.ImpressionTracker.prototype.handleIntersectionChanges;
-
-  gaplugins.ImpressionTracker.prototype.handleIntersectionChanges =
-      function(records) {
-
-    var sortedRecords = [];
-    for (var i = 0, item; item = this.items[i]; i++) {
-      for (var j = 0, record; record = records[j]; j++) {
-        if (record.target.id === item.id) {
-          sortedRecords.push(record);
-          continue;
-        }
-      }
-    }
-    originalHandleIntersectionChanges.call(this, sortedRecords);
-  }
-  </script>
+  <script async src="/autotrack.js"></script>
   <script async src="https://www.google-analytics.com/analytics.js"></script>
   <style>
     html, body { margin: 0; overflow: auto; }

--- a/test/impression-tracker.js
+++ b/test/impression-tracker.js
@@ -23,6 +23,27 @@ var constants = require('../lib/constants');
 var browserCaps;
 
 
+var elementIdsByDomOrder = [
+  'foo',
+  'foo-1',
+  'foo-1-1',
+  'foo-1-2',
+  'foo-2',
+  'foo-2-1',
+  'foo-2-2',
+  'bar',
+  'bar-1',
+  'bar-1-1',
+  'bar-1-2',
+  'bar-2',
+  'bar-2-1',
+  'bar-2-2',
+  'attrs',
+  'attrs-1',
+  'attrs-2'
+];
+
+
 describe('impressionTracker', function() {
 
   before(function() {
@@ -320,7 +341,7 @@ describe('impressionTracker', function() {
           ['[1].eventCategory', 'Viewport'],
           ['[1].eventAction', 'impression'],
           ['[1].eventLabel', 'foo-2-2']
-        ]));
+        ], sortHitDataByEventLabel));
   });
 
 
@@ -466,7 +487,7 @@ describe('impressionTracker', function() {
             ['[2].eventCategory', 'Viewport'],
             ['[2].eventAction', 'impression'],
             ['[2].eventLabel', 'foo-2'],
-          ]));
+          ], sortHitDataByEventLabel));
 
       browser
           .scroll('#bar')
@@ -481,7 +502,7 @@ describe('impressionTracker', function() {
             ['[5].eventCategory', 'Viewport'],
             ['[5].eventAction', 'impression'],
             ['[5].eventLabel', 'bar-2'],
-          ]));
+          ], sortHitDataByEventLabel));
     });
   });
 
@@ -553,7 +574,7 @@ describe('impressionTracker', function() {
             ['[4].eventCategory', 'Viewport'],
             ['[4].eventAction', 'impression'],
             ['[4].eventLabel', 'foo-2-1'],
-          ]));
+          ], sortHitDataByEventLabel));
     });
   });
 
@@ -648,4 +669,19 @@ function addFixtures() {
 function removeFixtures() {
   var fixture = document.getElementById('fixture');
   document.body.removeChild(fixture);
+}
+
+/**
+ * A comparison function that sorts hits by the `eventLabel` value.
+ * This is needed to work around Chrome's non-deterministic firing of
+ * IntersectionObserver callbacks when multiple instances are used.
+ * @param {Object} a The first hit to compare.
+ * @param {Object} b The second hit to compare.
+ * @return {number} A negative number if a should appear first in the sorted
+ *     array, and a positive number if b should appear first.
+ */
+function sortHitDataByEventLabel(a, b) {
+  var aDomIndex = elementIdsByDomOrder.indexOf(a.eventLabel);
+  var bDomIndex = elementIdsByDomOrder.indexOf(b.eventLabel);
+  return aDomIndex - bDomIndex;
 }

--- a/test/impression-tracker.js
+++ b/test/impression-tracker.js
@@ -456,7 +456,7 @@ describe('impressionTracker', function() {
   });
 
 
-  describe('addElements', function() {
+  describe('observeElements', function() {
 
     it('adds elements to be observed for intersections', function() {
 
@@ -470,7 +470,7 @@ describe('impressionTracker', function() {
               'foo-2',
             ]
           })
-          .execute(ga.run, 'impressionTracker:addElements', [
+          .execute(ga.run, 'impressionTracker:observeElements', [
             {id: 'bar', threshold: 0},
             {id: 'bar-1', threshold: 0.5},
             {id: 'bar-2', threshold: 1},
@@ -507,7 +507,7 @@ describe('impressionTracker', function() {
   });
 
 
-  describe('removeElements', function() {
+  describe('unobserveElements', function() {
 
     it('removes elements from being observed for intersections', function() {
 
@@ -521,7 +521,7 @@ describe('impressionTracker', function() {
               'foo-2',
             ]
           })
-          .execute(ga.run, 'impressionTracker:removeElements', ['foo'])
+          .execute(ga.run, 'impressionTracker:unobserveElements', ['foo'])
           .scroll('#foo')
           .waitUntil(ga.hitDataMatches([
             ['length', 2],
@@ -550,7 +550,7 @@ describe('impressionTracker', function() {
               {id: 'foo-2-2', threshold: 1, trackFirstImpressionOnly: true},
             ]
           })
-          .execute(ga.run, 'impressionTracker:removeElements', [
+          .execute(ga.run, 'impressionTracker:unobserveElements', [
             'foo',
             'foo-1', // Mismatch.
             {id: 'foo-1-1', threshold: 0.5}, // Mismatch.
@@ -578,7 +578,7 @@ describe('impressionTracker', function() {
     });
   });
 
-  describe('removeAllElements', function() {
+  describe('unobserveAllElements', function() {
 
     it('removes all elements from being observed for intersections',
         function() {
@@ -593,8 +593,8 @@ describe('impressionTracker', function() {
               'foo-2',
             ]
           })
-          .execute(ga.run, 'impressionTracker:removeAllElements')
-          .execute(ga.run, 'impressionTracker:addElements', [
+          .execute(ga.run, 'impressionTracker:unobserveAllElements')
+          .execute(ga.run, 'impressionTracker:observeElements', [
             'foo-1-1',
             'foo-2-2',
           ])

--- a/test/impression-tracker.js
+++ b/test/impression-tracker.js
@@ -434,6 +434,164 @@ describe('impressionTracker', function() {
     assert.equal(hitData[0][constants.USAGE_PARAM], '4');
   });
 
+
+  describe('addElements', function() {
+
+    it('adds elements to be observed for intersections', function() {
+
+      if (notSupportedInBrowser()) return;
+
+      browser
+          .execute(ga.run, 'require', 'impressionTracker', {
+            elements: [
+              'foo',
+              'foo-1',
+              'foo-2',
+            ]
+          })
+          .execute(ga.run, 'impressionTracker:addElements', [
+            {id: 'bar', threshold: 0},
+            {id: 'bar-1', threshold: 0.5},
+            {id: 'bar-2', threshold: 1},
+          ])
+          .scroll('#foo')
+          .waitUntil(ga.hitDataMatches([
+            ['length', 3],
+            ['[0].eventCategory', 'Viewport'],
+            ['[0].eventAction', 'impression'],
+            ['[0].eventLabel', 'foo'],
+            ['[1].eventCategory', 'Viewport'],
+            ['[1].eventAction', 'impression'],
+            ['[1].eventLabel', 'foo-1'],
+            ['[2].eventCategory', 'Viewport'],
+            ['[2].eventAction', 'impression'],
+            ['[2].eventLabel', 'foo-2'],
+          ]));
+
+      browser
+          .scroll('#bar')
+          .waitUntil(ga.hitDataMatches([
+            ['length', 6],
+            ['[3].eventCategory', 'Viewport'],
+            ['[3].eventAction', 'impression'],
+            ['[3].eventLabel', 'bar'],
+            ['[4].eventCategory', 'Viewport'],
+            ['[4].eventAction', 'impression'],
+            ['[4].eventLabel', 'bar-1'],
+            ['[5].eventCategory', 'Viewport'],
+            ['[5].eventAction', 'impression'],
+            ['[5].eventLabel', 'bar-2'],
+          ]));
+    });
+  });
+
+
+  describe('removeElements', function() {
+
+    it('removes elements from being observed for intersections', function() {
+
+      if (notSupportedInBrowser()) return;
+
+      browser
+          .execute(ga.run, 'require', 'impressionTracker', {
+            elements: [
+              'foo',
+              'foo-1',
+              'foo-2',
+            ]
+          })
+          .execute(ga.run, 'impressionTracker:removeElements', ['foo'])
+          .scroll('#foo')
+          .waitUntil(ga.hitDataMatches([
+            ['length', 2],
+            ['[0].eventCategory', 'Viewport'],
+            ['[0].eventAction', 'impression'],
+            ['[0].eventLabel', 'foo-1'],
+            ['[1].eventCategory', 'Viewport'],
+            ['[1].eventAction', 'impression'],
+            ['[1].eventLabel', 'foo-2'],
+          ]));
+    });
+
+    it('only removes elements if all properties match', function() {
+
+      if (notSupportedInBrowser()) return;
+
+      browser
+          .execute(ga.run, 'require', 'impressionTracker', {
+            elements: [
+              {id: 'foo', threshold: 0},
+              {id: 'foo-1', threshold: 0.5, trackFirstImpressionOnly: false},
+              {id: 'foo-1-1', threshold: 0.5, trackFirstImpressionOnly: false},
+              {id: 'foo-1-2', threshold: 0.5, trackFirstImpressionOnly: false},
+              {id: 'foo-2', threshold: 1, trackFirstImpressionOnly: true},
+              {id: 'foo-2-1', threshold: 1, trackFirstImpressionOnly: true},
+              {id: 'foo-2-2', threshold: 1, trackFirstImpressionOnly: true},
+            ]
+          })
+          .execute(ga.run, 'impressionTracker:removeElements', [
+            'foo',
+            'foo-1', // Mismatch.
+            {id: 'foo-1-1', threshold: 0.5}, // Mismatch.
+            {id: 'foo-2-2', threshold: 1},
+          ])
+          .scroll('#foo')
+          .waitUntil(ga.hitDataMatches([
+            ['length', 5],
+            ['[0].eventCategory', 'Viewport'],
+            ['[0].eventAction', 'impression'],
+            ['[0].eventLabel', 'foo-1'],
+            ['[1].eventCategory', 'Viewport'],
+            ['[1].eventAction', 'impression'],
+            ['[1].eventLabel', 'foo-1-1'],
+            ['[2].eventCategory', 'Viewport'],
+            ['[2].eventAction', 'impression'],
+            ['[2].eventLabel', 'foo-1-2'],
+            ['[3].eventCategory', 'Viewport'],
+            ['[3].eventAction', 'impression'],
+            ['[3].eventLabel', 'foo-2'],
+            ['[4].eventCategory', 'Viewport'],
+            ['[4].eventAction', 'impression'],
+            ['[4].eventLabel', 'foo-2-1'],
+          ]));
+    });
+  });
+
+  describe('removeAllElements', function() {
+
+    it('removes all elements from being observed for intersections',
+        function() {
+
+      if (notSupportedInBrowser()) return;
+
+      browser
+          .execute(ga.run, 'require', 'impressionTracker', {
+            elements: [
+              'foo',
+              'foo-1',
+              'foo-2',
+            ]
+          })
+          .execute(ga.run, 'impressionTracker:removeAllElements')
+          .execute(ga.run, 'impressionTracker:addElements', [
+            'foo-1-1',
+            'foo-2-2',
+          ])
+          .scroll('#foo')
+          .waitUntil(ga.hitDataMatches([
+            ['length', 2],
+            ['[0].eventCategory', 'Viewport'],
+            ['[0].eventAction', 'impression'],
+            ['[0].eventLabel', 'foo-1-1'],
+            ['[1].eventCategory', 'Viewport'],
+            ['[1].eventAction', 'impression'],
+            ['[1].eventLabel', 'foo-2-2'],
+          ]));
+
+    });
+
+  });
+
 });
 
 


### PR DESCRIPTION
Address #102 by adding the `observeElements`, `unobserveElements`, and `unobserveAllElements` methods to the `impressionTracker` plugin.