### PR TITLE
Add an autotrack build tool

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "env": {
     "browser": true,
     "es6": true,
+    "node": true,
   },
   "parserOptions": {
     "sourceType": "module",

--- a/bin/autotrack
+++ b/bin/autotrack
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/* eslint no-console: "off" */
+
+
+const chalk = require('chalk');
+const fs = require('fs-extra');
+const gzipSize = require('gzip-size');
+const minimist = require('minimist');
+const path = require('path');
+const build = require('./build');
+const logErrors = require('./errors');
+
+
+const argv = minimist(process.argv.slice(2));
+const noArgsPassed = Object.keys(argv).length === 1 && argv._.length === 0;
+const output = argv.o || argv.output || 'autotrack.js';
+const plugins = (argv.p || argv.plugins || '').split(/\s*,\s*/);
+
+
+if (argv.h || argv.help || noArgsPassed) {
+  fs.createReadStream(path.join(__dirname, '../bin/usage.txt'))
+      .pipe(process.stderr);
+}
+else {
+  const {cyan, gray, green, red} = chalk;
+
+  if (!(plugins.length)) {
+    console.error(red('At least one plugin must be specified'));
+    process.exit(1);
+  }
+
+  build(output, plugins)
+      .then(({code, map}) => {
+        fs.outputFileSync(output, code, 'utf-8');
+        fs.outputFileSync(`${output}.map`, map, 'utf-8');
+
+        const size = (gzipSize.sync(code) / 1000).toFixed(1);
+
+        console.log(green(`\nGreat success!\n`));
+        console.log(cyan('Built: ') +
+            `${output} ${gray(`(${size} Kb gzipped)`)}`);
+        console.log(cyan('Built: ') +
+            `${output}.map\n`);
+      })
+      .catch(logErrors)
+      .catch(console.error.bind(console));
+}

--- a/bin/build.js
+++ b/bin/build.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/* eslint-env node */
+/* eslint require-jsdoc: "off" */
+
+
+const fs = require('fs-extra');
+const glob = require('glob');
+const {compile}= require('google-closure-compiler-js');
+const {rollup} = require('rollup');
+const memory = require('rollup-plugin-memory');
+const nodeResolve = require('rollup-plugin-node-resolve');
+const path = require('path');
+const {SourceMapGenerator, SourceMapConsumer} = require('source-map');
+
+
+const kebabCase = (str) => {
+  return str.replace(/([A-Z])/g, (match, p1) => `-${p1.toLowerCase()}`)
+};
+
+
+module.exports = (output, autotrackPlugins = []) => {
+  const entryPath = path.resolve(__dirname, '../lib/index.js');
+  const entry = autotrackPlugins.length === 0 ? entryPath : {
+    path: entryPath,
+    contents: autotrackPlugins
+        .map((plugin) => `import './plugins/${kebabCase(plugin)}';`)
+        .join('\n'),
+  };
+  const plugins = [nodeResolve()];
+  if (autotrackPlugins.length) plugins.push(memory());
+
+  return new Promise((resolve, reject) => {
+    rollup({entry, plugins}).then((bundle) => {
+      try {
+        const rollupResult = bundle.generate({
+          format: 'es',
+          dest: output,
+          sourceMap: true,
+        });
+
+        const externsDir = path.resolve(__dirname, '../lib/externs');
+        const externs = glob.sync(path.join(externsDir, '*.js'))
+            .reduce((acc, cur) => acc + fs.readFileSync(cur, 'utf-8'), '');
+
+        const closureFlags = {
+          jsCode: [{
+            src: rollupResult.code,
+            path: path.basename(output),
+          }],
+          compilationLevel: 'ADVANCED',
+          useTypesForOptimization: true,
+          outputWrapper:
+              '(function(){%output%})();\n' +
+              `//# sourceMappingURL=${path.basename(output)}.map`,
+          assumeFunctionWrapper: true,
+          rewritePolyfills: false,
+          warningLevel: 'VERBOSE',
+          createSourceMap: true,
+          externs: [{src: externs}],
+        };
+
+        const closureResult = compile(closureFlags);
+
+        if (closureResult.errors.length || closureResult.warnings.length) {
+          const rollupMap = new SourceMapConsumer(rollupResult.map);
+
+          // Remap errors from the closure compiler output to the original
+          // files before rollup bundled them.
+          const remap = (type) => (item) => {
+            let {line, column, source} = rollupMap.originalPositionFor({
+              line: item.lineNo,
+              column: item.charNo,
+            });
+            source = path.relative('.', path.resolve(__dirname, source));
+            return {type, line, column, source, desc: item.description};
+          };
+
+          reject({
+            errors: [
+              ...closureResult.errors.map(remap('error')),
+              ...closureResult.warnings.map(remap('warning')),
+            ],
+          });
+        } else {
+          // Currently, closure compiler doesn't support applying its generated
+          // source map to an existing source map, so we do it manually.
+          const fromMap = JSON.parse(closureResult.sourceMap);
+          const toMap = rollupResult.map;
+
+          const generator = SourceMapGenerator.fromSourceMap(
+              new SourceMapConsumer(fromMap));
+
+          generator.applySourceMap(
+              new SourceMapConsumer(toMap), path.basename(output))
+
+          const sourceMap = generator.toString();
+
+          resolve({
+            code: closureResult.compiledCode,
+            map: sourceMap,
+          });
+        }
+      } catch(err) {
+        reject(err);
+      }
+    }).catch(reject);
+  });
+};

--- a/bin/errors.js
+++ b/bin/errors.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+const chalk = require('chalk');
+
+
+const log = (msg) => process.stderr.write(msg);
+
+
+module.exports = (err) => {
+  if (err instanceof Error) {
+    log(`\n${err.stack}\n`);
+  } else {
+    log('\n');
+    for (let {source, line, column, desc, type} of err.errors) {
+      const color = chalk[type == 'error' ? 'red' : 'yellow'];
+
+      log(`${color(`[${type}]`)} ${desc}\n`);
+      log(chalk.gray(`${source} [${line}:${column}]\n\n`));
+    }
+  }
+};

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -1,0 +1,20 @@
+
+Usage: autotrack [options]
+
+  Generates a minified, autotrack file and source map with only the specified
+  autotrack plugins.
+
+Example:
+
+  autotrack -p outboundLinkTracker,maxScrollTracker,urlChangeTracker
+
+Options:
+
+  -o, --output       The output path for the generated file and source map.
+                     Defaults to "autotrack.js" and "autotrack.js.map"
+                     (Note: the source map filename will append ".map").
+
+  -p, --plugins      A comma-separated list of plugin names.
+
+  -h, --help         Displays this help message.
+

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
   },
   "homepage": "https://github.com/googleanalytics/autotrack#readme",
   "dependencies": {
-    "dom-utils": "^0.9.0"
+    "chalk": "^1.1.3",
+    "dom-utils": "^0.9.0",
+    "fs-extra": "^2.0.0",
+    "gzip-size": "^3.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",


### PR DESCRIPTION
```
Usage: autotrack [options]

  Generates a minified, autotrack file and source map with only the specified
  autotrack plugins.

Example:

  autotrack -p outboundLinkTracker,maxScrollTracker,urlChangeTracker

Options:

  -o, --output       The output path for the generated file and source map.
                     Defaults to "autotrack.js" and "autotrack.js.map"
                     (Note: the source map filename will append ".map").

  -p, --plugins      A comma-separated list of plugin names.

  -h, --help         Displays this help message.
```