### PR TITLE
Add a visibleThreshold option to pageVisibilityTracker

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -85,7 +85,7 @@ gulp.task('javascript', () => {
 gulp.task('javascript:unit', ((compiler) => {
   const createCompiler = () => {
     return webpack({
-      entry: glob.sync('./test/unit/*-test.js'),
+      entry: glob.sync('./test/unit/**/*-test.js'),
       output: {
         path: 'test/unit',
         filename: 'index.js',

--- a/lib/plugins/page-visibility-tracker.js
+++ b/lib/plugins/page-visibility-tracker.js
@@ -49,6 +49,7 @@ class PageVisibilityTracker {
     /** @type {PageVisibilityTrackerOpts} */
     const defaultOpts = {
       sessionTimeout: Session.DEFAULT_TIMEOUT,
+      visibleThreshold: 5 * SECONDS,
       // timeZone: undefined,
       // visibleMetricIndex: undefined,
       fieldsObj: {},
@@ -106,6 +107,12 @@ class PageVisibilityTracker {
       pageId: PAGE_ID,
     };
 
+    // If the visibilityState has changed to hidden, clear any scheduled
+    // pageviews waiting for the visibleThreshold timeout.
+    if (this.visibleThresholdTimeout_ && document.visibilityState == HIDDEN) {
+      clearTimeout(this.visibleThresholdTimeout_);
+    }
+
     if (this.session.isExpired()) {
       if (document.visibilityState == HIDDEN) {
         // Hidden events should never be sent if a session has expired (if
@@ -117,14 +124,24 @@ class PageVisibilityTracker {
         // This behavior ensures all sessions contain a pageview so
         // session-level page dimensions and metrics (e.g. ga:landingPagePath
         // and ga:entrances) are correct.
+        // Also, in order to prevent false positives, we add a small timeout
+        // that is cleared if the visibilityState changes to hidden shortly
+        // after the change to visible. This can happen if a user is switching
+        // through a bunch of open tabs but not actually interacting with the
+        // site.
+        clearTimeout(this.visibleThresholdTimeout_);
+        this.visibleThresholdTimeout_ = setTimeout(() => {
+          /** @type {FieldsObj} */
+          const defaultFields = {
+            transport: 'beacon',
+            queueTime: now() - change.time,
+          };
+          this.tracker.send('pageview',
+              createFieldsObj(defaultFields, this.opts.fieldsObj,
+                  this.tracker, this.opts.hitFilter));
 
-        /** @type {FieldsObj} */
-        const defaultFields = {transport: 'beacon'};
-        this.tracker.send('pageview',
-            createFieldsObj(defaultFields, this.opts.fieldsObj,
-                this.tracker, this.opts.hitFilter));
-
-        this.store.set(change);
+          this.store.set(change);
+        }, this.opts.visibleThreshold);
       }
     } else {
       if (lastStoredChange.pageId == PAGE_ID &&
@@ -174,33 +191,35 @@ class PageVisibilityTracker {
    *     original order when reporting across multiple windows/tabs.
    */
   sendPageVisibilityEvent(lastStoredChange, hitTime = undefined) {
-    /** @type {FieldsObj} */
-    const defaultFields = {
-      transport: 'beacon',
-      nonInteraction: true,
-      eventCategory: 'Page Visibility',
-      eventAction: 'track',
-      eventLabel: NULL_DIMENSION,
-    };
-    if (hitTime) {
-      defaultFields.queueTime = now() - hitTime;
-    }
-
     const delta = this.getTimeSinceLastStoredChange(lastStoredChange, hitTime);
 
-    // If at least a one second delta exists, report it.
-    if (delta) {
-      defaultFields.eventValue = delta;
+    // If the detla is greater than the visibileThreshold, report it.
+    if (delta && delta >= this.opts.visibleThreshold) {
+      const deltaInSeconds = Math.round(delta / SECONDS);
+
+      /** @type {FieldsObj} */
+      const defaultFields = {
+        transport: 'beacon',
+        nonInteraction: true,
+        eventCategory: 'Page Visibility',
+        eventAction: 'track',
+        eventValue: deltaInSeconds,
+        eventLabel: NULL_DIMENSION,
+      };
+
+      if (hitTime) {
+        defaultFields.queueTime = now() - hitTime;
+      }
 
       // If a custom metric was specified, set it equal to the event value.
       if (this.opts.visibleMetricIndex) {
-        defaultFields['metric' + this.opts.visibleMetricIndex] = delta;
+        defaultFields['metric' + this.opts.visibleMetricIndex] = deltaInSeconds;
       }
-    }
 
-    this.tracker.send('event',
-        createFieldsObj(defaultFields, this.opts.fieldsObj,
-            this.tracker, this.opts.hitFilter));
+      this.tracker.send('event',
+          createFieldsObj(defaultFields, this.opts.fieldsObj,
+              this.tracker, this.opts.hitFilter));
+    }
   }
 
   /**
@@ -233,8 +252,8 @@ class PageVisibilityTracker {
    */
   getTimeSinceLastStoredChange(lastStoredChange, hitTime = now()) {
     const isSessionActive = !this.session.isExpired();
-    const timeSinceLastStoredChange = lastStoredChange.time &&
-        Math.round((hitTime - lastStoredChange.time) / SECONDS);
+    const timeSinceLastStoredChange =
+        lastStoredChange.time && hitTime - lastStoredChange.time;
 
     return isSessionActive &&
         timeSinceLastStoredChange > 0 ? timeSinceLastStoredChange : 0;

--- a/lib/plugins/page-visibility-tracker.js
+++ b/lib/plugins/page-visibility-tracker.js
@@ -304,6 +304,7 @@ class PageVisibilityTracker {
    * Removes all event listeners and restores overridden methods.
    */
   remove() {
+    this.store.destroy();
     this.session.destroy();
     MethodChain.remove(this.tracker, 'set', this.trackerSetOverride);
     window.removeEventListener('unload', this.handleWindowUnload);

--- a/test/unit/index.html
+++ b/test/unit/index.html
@@ -42,7 +42,8 @@
       });
     });
   </script>
-  <!-- Note: uncomment when needed. Don't use when running tests.
+  <!-- Note: uncomment when needed. Don't use when running tests. -->
+  <!--
   <script src="/node_modules/source-map-support/browser-source-map-support.js"></script>
   <script>sourceMapSupport.install();</script>
   -->

--- a/test/unit/plugins/page-visibility-tracker-test.js
+++ b/test/unit/plugins/page-visibility-tracker-test.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import assert from 'assert';
+import sinon from 'sinon';
+import '../../../lib/plugins/page-visibility-tracker';
+import store from '../../../lib/store';
+
+
+const TRACKING_ID = 'UA-12345-1';
+const DEFAULT_SESSION_TIMEOUT = 30;
+const DEFAULT_VISIBLE_THRESHOLD = 5000;
+
+
+describe('PageVisibilityTracker', function() {
+  let tracker;
+  let PageVisibilityTracker;
+
+  beforeEach(function(done) {
+    localStorage.clear();
+    window.ga('create', TRACKING_ID, 'auto');
+    window.ga(function(t) {
+      tracker = t;
+      PageVisibilityTracker = window.gaplugins.PageVisibilityTracker;
+      done();
+    });
+  });
+
+  afterEach(function() {
+    localStorage.clear();
+    window.ga('remove');
+  });
+
+  describe('constructor', function() {
+    it('stores the tracker on the instance', function() {
+      const pvt = new PageVisibilityTracker(tracker);
+      assert.strictEqual(tracker, pvt.tracker);
+
+      pvt.remove();
+    });
+
+    it('merges the passed options with the defaults', function() {
+      let pvt = new PageVisibilityTracker(tracker);
+
+      assert.deepEqual(pvt.opts, {
+        sessionTimeout: DEFAULT_SESSION_TIMEOUT,
+        visibleThreshold: DEFAULT_VISIBLE_THRESHOLD,
+        fieldsObj: {},
+      });
+      pvt.remove();
+
+      const opts = {
+        sessionTimeout: 5,
+        visibleThreshold: 0,
+        timeZone: 'America/Los_Angeles',
+        visibleMetricIndex: 2,
+        fieldsObj: {nonInteraction: true},
+        hitFilter: sinon.stub()
+      };
+      pvt = new PageVisibilityTracker(tracker, opts);
+      assert.deepEqual(pvt.opts, opts);
+      pvt.remove();
+    });
+
+    it('stores the initial visibility state', function() {
+      const pvt = new PageVisibilityTracker(tracker);
+
+      const storeData = pvt.store.get();
+      assert(storeData.state);
+      assert(storeData.time);
+      assert(storeData.pageId);
+
+      const localStorageData = JSON.parse(localStorage.getItem(
+          `autotrack:${TRACKING_ID}:plugins/page-visibility-tracker`));
+      assert(localStorageData.state);
+      assert(localStorageData.time);
+      assert(localStorageData.pageId);
+
+      pvt.remove();
+    });
+  });
+});


### PR DESCRIPTION
The `visibleThreshold` option helps reduce unnecessary hits when a user switches tabs only to switch away (or close the tab) almost immediately. These fast switches can sometimes lead to increased session counts, where the only user action in the session is the user immediately closing the tab.

The default `visibleThreshold` is `5000` ms, which means a Page Visibility event is not sent unless the page is in the visible state for at least that long. Similarly, a new pageview won't be sent after session timeouts unless the user is in the visible state for at least the `visibleThreshold` time.