### PR TITLE
Change babel preset es2015 in favour of env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,5 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    ["env", { "targets": { "browsers": ["last 2 versions", "ie >= 9"] } }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-external-helpers": "^6.22.0",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-env": "~1.2.1",
     "babel-register": "^6.22.0",
     "easy-sauce": "^0.4.1",
     "eslint": "^3.14.0",


### PR DESCRIPTION
Hello,

https://github.com/babel/babel-preset-env is the uniform way to ship prefixed builds.

I adjusted the build for the common user case, but feel free to edit it.

Babel community is adopting this approach because it is align with the standard language specifications.