### PR TITLE
Add an option to let the pageVisibilityTracker plugin send the initial pageview

### DIFF
--- a/lib/externs/page-visibility-tracker.js
+++ b/lib/externs/page-visibility-tracker.js
@@ -4,6 +4,8 @@
  *   sessionTimeout: (number),
  *   visibleThreshold: (number),
  *   timeZone: (string|undefined),
+ *   sendInitialPageview: (boolean),
+ *   pageloadMetricIndex: (number|undefined),
  *   visibleMetricIndex: (number|undefined),
  *   fieldsObj: (!Object),
  *   hitFilter: (Function|undefined),

--- a/lib/externs/page-visibility-tracker.js
+++ b/lib/externs/page-visibility-tracker.js
@@ -5,7 +5,7 @@
  *   visibleThreshold: (number),
  *   timeZone: (string|undefined),
  *   sendInitialPageview: (boolean),
- *   pageloadMetricIndex: (number|undefined),
+ *   pageLoadMetricIndex: (number|undefined),
  *   visibleMetricIndex: (number|undefined),
  *   fieldsObj: (!Object),
  *   hitFilter: (Function|undefined),

--- a/lib/plugins/page-visibility-tracker.js
+++ b/lib/plugins/page-visibility-tracker.js
@@ -51,6 +51,8 @@ class PageVisibilityTracker {
       sessionTimeout: Session.DEFAULT_TIMEOUT,
       visibleThreshold: 5 * SECONDS,
       // timeZone: undefined,
+      sendInitialPageview: false,
+      // pageloadMetricIndex: undefined,
       // visibleMetricIndex: undefined,
       fieldsObj: {},
       // hitFilter: undefined
@@ -62,6 +64,7 @@ class PageVisibilityTracker {
     this.tracker = tracker;
     this.lastPageState = null;
     this.visibleThresholdTimeout_ = null;
+    this.isInitialPageviewSent_ = false;
 
     // Binds methods to `this`.
     this.trackerSetOverride = this.trackerSetOverride.bind(this);
@@ -82,10 +85,16 @@ class PageVisibilityTracker {
     MethodChain.add(tracker, 'set', this.trackerSetOverride);
 
     window.addEventListener('unload', this.handleWindowUnload);
-
     document.addEventListener('visibilitychange', this.handleChange);
+
     if (document.visibilityState == VISIBLE) {
+      if (this.opts.sendInitialPageview) {
+        this.sendPageview({isPageLoad: true});
+        this.isInitialPageviewSent_ = true;
+      }
       this.handleChange();
+    } else {
+      this.sendPageload();
     }
   }
 
@@ -114,6 +123,16 @@ class PageVisibilityTracker {
       pageId: PAGE_ID,
     };
 
+    // If the visibilityState has changed to visible and the initial pageview
+    // has not been sent (and the `sendInitialPageview` option is `true`).
+    // Send the initial pageview now.
+    if (!this.isInitialPageviewSent_ &&
+        this.opts.sendInitialPageview &&
+        document.visibilityState == VISIBLE) {
+      this.sendPageview();
+      this.isInitialPageviewSent_ = true;
+    }
+
     // If the visibilityState has changed to hidden, clear any scheduled
     // pageviews waiting for the visibleThreshold timeout.
     if (this.visibleThresholdTimeout_ && document.visibilityState == HIDDEN) {
@@ -136,16 +155,8 @@ class PageVisibilityTracker {
         // immediately close it. Such cases should not be considered pageviews.
         clearTimeout(this.visibleThresholdTimeout_);
         this.visibleThresholdTimeout_ = setTimeout(() => {
-          /** @type {FieldsObj} */
-          const defaultFields = {
-            transport: 'beacon',
-            queueTime: now() - change.time,
-          };
-          this.tracker.send('pageview',
-              createFieldsObj(defaultFields, this.opts.fieldsObj,
-                  this.tracker, this.opts.hitFilter));
-
           this.store.set(change);
+          this.sendPageview({hitTime: change.time});
         }, this.opts.visibleThreshold);
       } else if (document.visibilityState == HIDDEN) {
         // Hidden events should never be sent if a session has expired (if
@@ -192,15 +203,17 @@ class PageVisibilityTracker {
   }
 
   /**
-   * Sends a Page Visibility event with the passed event action and visibility
-   * state. If a previous state change exists within the same session, the time
-   * delta is tracked as the event label and optionally as a custom metric.
+   * Sends a Page Visibility event to track the time this page was in the
+   * visible state (assuming it was in that state long enough to meet the
+   * threshold).
    * @param {PageVisibilityStoreData} lastStoredChange
-   * @param {number|undefined=} hitTime A hit timestap used to help ensure
-   *     original order when reporting across multiple windows/tabs.
+   * @param {{hitTime: (number|undefined)}=} param1
+   *     - hitTime: A hit timestap used to help ensure original order in cases
+   *                where the send is delayed.
    */
-  sendPageVisibilityEvent(lastStoredChange, hitTime = undefined) {
-    const delta = this.getTimeSinceLastStoredChange(lastStoredChange, hitTime);
+  sendPageVisibilityEvent(lastStoredChange, {hitTime} = {}) {
+    const delta = this.getTimeSinceLastStoredChange(
+        lastStoredChange, {hitTime});
 
     // If the detla is greater than the visibileThreshold, report it.
     if (delta && delta >= this.opts.visibleThreshold) {
@@ -232,6 +245,45 @@ class PageVisibilityTracker {
   }
 
   /**
+   * Sends a pageload if a custom pageload metric is being used.
+   */
+  sendPageload() {
+    if (this.opts.sendInitialPageview && this.opts.pageloadMetricIndex) {
+      /** @type {FieldsObj} */
+      const defaultFields = {
+        transport: 'beacon',
+        eventCategory: 'Page Visibility',
+        eventAction: 'pageload',
+        eventLabel: NULL_DIMENSION,
+        ['metric' + this.opts.pageloadMetricIndex]: 1,
+      };
+      this.tracker.send('event',
+          createFieldsObj(defaultFields, this.opts.fieldsObj,
+              this.tracker, this.opts.hitFilter));
+    }
+  }
+
+  /**
+   * Sends a pageview, optionally calculating an offset if hitTime is passed.
+   * @param {{
+   *   hitTime: (number|undefined),
+   *   isPageLoad: (boolean|undefined)
+   * }=} param1
+   *     hitTime: The timestamp of the current hit.
+   *     isPageLoad: True if this pageview was also a pageload.
+   */
+  sendPageview({hitTime, isPageLoad} = {}) {
+    /** @type {FieldsObj} */
+    const defaultFields = {transport: 'beacon'};
+    if (hitTime) defaultFields.queueTime = now() - hitTime;
+    if (isPageLoad) defaultFields['metric' + this.opts.pageloadMetricIndex] = 1;
+
+    this.tracker.send('pageview',
+        createFieldsObj(defaultFields, this.opts.fieldsObj,
+            this.tracker, this.opts.hitFilter));
+  }
+
+  /**
    * Detects changes to the tracker object and triggers an update if the page
    * field has changed.
    * @param {function((Object|string), (string|undefined))} originalMethod
@@ -255,17 +307,13 @@ class PageVisibilityTracker {
    * Calculates the time since the last visibility change event in the current
    * session. If the session has expired the reported time is zero.
    * @param {PageVisibilityStoreData} lastStoredChange
-   * @param {number=} hitTime The timestamp of the current hit, defaulting
-   *     to now.
+   * @param {{hitTime: (number|undefined)}=} param1
+   *     hitTime: The time of the current hit (defaults to now).
    * @return {number} The time (in ms) since the last change.
    */
-  getTimeSinceLastStoredChange(lastStoredChange, hitTime = now()) {
-    const isSessionActive = !this.session.isExpired();
-    const timeSinceLastStoredChange =
-        lastStoredChange.time && hitTime - lastStoredChange.time;
-
-    return isSessionActive &&
-        timeSinceLastStoredChange > 0 ? timeSinceLastStoredChange : 0;
+  getTimeSinceLastStoredChange(lastStoredChange, {hitTime} = {}) {
+    return lastStoredChange.time && !this.session.isExpired() ?
+        (hitTime || now()) - lastStoredChange.time : 0;
   }
 
   /**
@@ -290,7 +338,7 @@ class PageVisibilityTracker {
     // data is correct).
     if (oldData.pageId == PAGE_ID &&
         oldData.state == VISIBLE) {
-      this.sendPageVisibilityEvent(oldData, newData.time);
+      this.sendPageVisibilityEvent(oldData, {hitTime: newData.time});
     }
   }
 

--- a/lib/plugins/page-visibility-tracker.js
+++ b/lib/plugins/page-visibility-tracker.js
@@ -256,6 +256,7 @@ class PageVisibilityTracker {
         eventAction: 'page load',
         eventLabel: NULL_DIMENSION,
         ['metric' + this.opts.pageLoadMetricIndex]: 1,
+        nonInteraction: true,
       };
       this.tracker.send('event',
           createFieldsObj(defaultFields, this.opts.fieldsObj,

--- a/lib/plugins/page-visibility-tracker.js
+++ b/lib/plugins/page-visibility-tracker.js
@@ -52,7 +52,7 @@ class PageVisibilityTracker {
       visibleThreshold: 5 * SECONDS,
       // timeZone: undefined,
       sendInitialPageview: false,
-      // pageloadMetricIndex: undefined,
+      // pageLoadMetricIndex: undefined,
       // visibleMetricIndex: undefined,
       fieldsObj: {},
       // hitFilter: undefined
@@ -245,17 +245,17 @@ class PageVisibilityTracker {
   }
 
   /**
-   * Sends a pageload if a custom pageload metric is being used.
+   * Sends a page load event if a custom page load metric is being used.
    */
   sendPageload() {
-    if (this.opts.sendInitialPageview && this.opts.pageloadMetricIndex) {
+    if (this.opts.sendInitialPageview && this.opts.pageLoadMetricIndex) {
       /** @type {FieldsObj} */
       const defaultFields = {
         transport: 'beacon',
         eventCategory: 'Page Visibility',
-        eventAction: 'pageload',
+        eventAction: 'page load',
         eventLabel: NULL_DIMENSION,
-        ['metric' + this.opts.pageloadMetricIndex]: 1,
+        ['metric' + this.opts.pageLoadMetricIndex]: 1,
       };
       this.tracker.send('event',
           createFieldsObj(defaultFields, this.opts.fieldsObj,
@@ -270,13 +270,13 @@ class PageVisibilityTracker {
    *   isPageLoad: (boolean|undefined)
    * }=} param1
    *     hitTime: The timestamp of the current hit.
-   *     isPageLoad: True if this pageview was also a pageload.
+   *     isPageLoad: True if this pageview was also a page load.
    */
   sendPageview({hitTime, isPageLoad} = {}) {
     /** @type {FieldsObj} */
     const defaultFields = {transport: 'beacon'};
     if (hitTime) defaultFields.queueTime = now() - hitTime;
-    if (isPageLoad) defaultFields['metric' + this.opts.pageloadMetricIndex] = 1;
+    if (isPageLoad) defaultFields['metric' + this.opts.pageLoadMetricIndex] = 1;
 
     this.tracker.send('pageview',
         createFieldsObj(defaultFields, this.opts.fieldsObj,

--- a/test/e2e/page-visibility-tracker-test.js
+++ b/test/e2e/page-visibility-tracker-test.js
@@ -250,6 +250,162 @@ describe('pageVisibilityTracker', function() {
     assert(end - start >= VISIBLE_THRESHOLD);
   });
 
+  it('sends the initial pageview when sendInitialPageview is set', function() {
+    if (!browserSupportsTabs()) return this.skip();
+
+    const opts = {
+      sendInitialPageview: true,
+      visibleThreshold: 0,
+    };
+
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+    browser.pause(500);
+
+    openNewTab('/test/e2e/fixtures/autotrack.html?tab=2');
+    browser.execute(ga.run, 'create', DEFAULT_TRACKER_FIELDS);
+    browser.execute(ga.logHitData, testId);
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+
+    browser.waitUntil(log.hitCountEquals(3));
+
+    const hits = log.getHits();
+    assert(hits[0].dl.endsWith('tab=1'));
+    assert.strictEqual(hits[0].t, 'pageview');
+    assert(hits[1].dl.endsWith('tab=1'));
+    assert.strictEqual(hits[1].ec, 'Page Visibility');
+    assert.strictEqual(hits[1].ea, 'track');
+    assert(hits[1].ev > 0);
+    assert(hits[2].dl.endsWith('tab=2'));
+    assert.strictEqual(hits[2].t, 'pageview');
+  });
+
+  it('sends a pageload metric when pageloadMetricIndex is set', function() {
+    if (!browserSupportsTabs()) return this.skip();
+
+    const opts = {
+      sendInitialPageview: true,
+      visibleThreshold: 0,
+      pageloadMetricIndex: 1,
+    };
+
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+
+    const backgroundTab = openNewTabInBackground(
+        '/test/e2e/fixtures/autotrack.html?tab=2');
+
+    browser.switchTab(backgroundTab);
+    browser.execute(ga.run, 'create', DEFAULT_TRACKER_FIELDS);
+    browser.execute(ga.logHitData, testId);
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+
+    browser.waitUntil(log.hitCountEquals(2));
+
+    const hits = log.getHits();
+    assert(hits[0].dl.endsWith('tab=1'));
+    assert.strictEqual(hits[0].t, 'pageview');
+    assert.strictEqual(hits[0].cm1, '1');
+    assert(hits[1].dl.endsWith('tab=2'));
+    assert.strictEqual(hits[1].ec, 'Page Visibility');
+    assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].cm1, '1');
+  });
+
+  it('delays sending the pageview until the state is visible', function() {
+    if (!browserSupportsTabs()) return this.skip();
+
+    const opts = {
+      sendInitialPageview: true,
+      visibleThreshold: 0,
+      pageloadMetricIndex: 1,
+    };
+
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+
+    const backgroundTab = openNewTabInBackground(
+        '/test/e2e/fixtures/autotrack.html?tab=2');
+
+    browser.switchTab(backgroundTab);
+    browser.execute(ga.run, 'create', DEFAULT_TRACKER_FIELDS);
+    browser.execute(ga.logHitData, testId);
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+    browser.waitUntil(log.hitCountEquals(2));
+
+    // The `switchTab()` command alone don't switch focus to the newly opened
+    // background tab, so we have to display an alert to force it.
+    browser.execute(() => {
+      alert('focus');
+    });
+    browser.pause(500);
+    browser.alertAccept();
+
+    browser.waitUntil(log.hitCountEquals(4));
+
+    const hits = log.getHits();
+    assert(hits[0].dl.endsWith('tab=1'));
+    assert.strictEqual(hits[0].t, 'pageview');
+    assert.strictEqual(hits[0].cm1, '1');
+    assert(hits[1].dl.endsWith('tab=2'));
+    assert.strictEqual(hits[1].ec, 'Page Visibility');
+    assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].cm1, '1');
+    assert(hits[2].dl.endsWith('tab=1'));
+    assert.strictEqual(hits[2].ec, 'Page Visibility');
+    assert.strictEqual(hits[2].ea, 'track');
+    assert(hits[2].ev > 0);
+    assert(hits[3].dl.endsWith('tab=2'));
+    assert.strictEqual(hits[3].t, 'pageview');
+    assert(!hits[3].cm1);
+  });
+
+  it('does not double-send pageviews on session timeout', function() {
+    if (!browserSupportsTabs()) return this.skip();
+
+    const opts = {
+      sendInitialPageview: true,
+      visibleThreshold: 0,
+      pageloadMetricIndex: 1,
+    };
+
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+
+    const backgroundTab = openNewTabInBackground(
+        '/test/e2e/fixtures/autotrack.html?tab=2');
+
+    browser.switchTab(backgroundTab);
+    browser.execute(ga.run, 'create', DEFAULT_TRACKER_FIELDS);
+    browser.execute(ga.logHitData, testId);
+    browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
+    browser.waitUntil(log.hitCountEquals(2));
+
+    expireSession();
+
+    // The `switchTab()` command alone don't switch focus to the newly opened
+    // background tab, so we have to display an alert to force it.
+    browser.execute(() => {
+      alert('focus');
+    });
+    browser.pause(500);
+    browser.alertAccept();
+
+    browser.waitUntil(log.hitCountEquals(3));
+
+    const hits = log.getHits();
+
+    log.removeHits();
+    log.assertNoHitsReceived();
+
+    assert(hits[0].dl.endsWith('tab=1'));
+    assert.strictEqual(hits[0].t, 'pageview');
+    assert.strictEqual(hits[0].cm1, '1');
+    assert(hits[1].dl.endsWith('tab=2'));
+    assert.strictEqual(hits[1].ec, 'Page Visibility');
+    assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].cm1, '1');
+    assert(hits[2].dl.endsWith('tab=2'));
+    assert.strictEqual(hits[2].t, 'pageview');
+    assert(!hits[2].cm1);
+  });
+
   it('handles closing a window/tab when a visible window is still open',
       function() {
     if (!browserSupportsTabs()) return this.skip();
@@ -711,7 +867,7 @@ function openNewTab(url) {
   const oldTabIds = browser.getTabIds();
   browser.execute((url) => {
     const a = document.createElement('a');
-    a.href = url || '/test/e2e/fixtures/blank.htm';
+    a.href = url || '/test/e2e/fixtures/blank.html';
     a.target = '_blank';
     a.id = 'new-tab-link';
     a.setAttribute('style', 'position:fixed;top:0;left:0;right:0;bottom:0');
@@ -731,6 +887,43 @@ function openNewTab(url) {
   }, 2000, 'New tab was never opened.', 500);
 
   return browser.getCurrentTabId();
+}
+
+
+/**
+ * Opens a new tab in the backround by inserting a link with target="_blank"
+ * into the DOM, pressing the meta key, and then clicking on it.
+ * @param {string} url A an optional URL to navigate to, defaulting to
+ *     '/test/e2e/fixtures/blank.htm'.
+ * @return {string} The tab ID.
+ */
+function openNewTabInBackground(url) {
+  const oldTabIds = browser.getTabIds();
+  browser.execute((url) => {
+    const a = document.createElement('a');
+    a.href = url || '/test/e2e/fixtures/blank.html';
+    a.id = 'new-tab-link';
+    a.setAttribute('style', 'position:fixed;top:0;left:0;right:0;bottom:0');
+    a.onclick = (event) => document.body.removeChild(a);
+    document.body.appendChild(a);
+  }, url);
+
+  browser.keys(['\uE03D']);
+  browser.element('#new-tab-link').click();
+  browser.keys(['\uE03D']);
+
+  browser.pause(500);
+  let backgroundTab;
+  browser.waitUntil(() => {
+    const newTabIds = browser.getTabIds();
+    if (newTabIds.length > oldTabIds.length) {
+      backgroundTab = newTabIds[newTabIds.length - 1];
+      return true;
+    }
+    return false;
+  }, 2000, 'New tab was never opened.', 500);
+
+  return backgroundTab;
 }
 
 

--- a/test/e2e/page-visibility-tracker-test.js
+++ b/test/e2e/page-visibility-tracker-test.js
@@ -153,7 +153,7 @@ describe('pageVisibilityTracker', function() {
     assert.strictEqual(hits[0].t, 'pageview');
   });
 
-  it('does not send a session-expiry pageview on initial pageload', function() {
+  it('does not send a session-expiry pageview on initial page load', function() {
     if (!browserSupportsTabs()) return this.skip();
 
     browser.execute(ga.run, 'require', 'pageVisibilityTracker', TEST_OPTS);
@@ -279,7 +279,7 @@ describe('pageVisibilityTracker', function() {
     assert.strictEqual(hits[2].t, 'pageview');
   });
 
-  it('sends a pageload metric when pageLoadMetricIndex is set', function() {
+  it('sends a page load metric when pageLoadMetricIndex is set', function() {
     if (!browserSupportsTabs()) return this.skip();
 
     const opts = {
@@ -306,7 +306,7 @@ describe('pageVisibilityTracker', function() {
     assert.strictEqual(hits[0].cm1, '1');
     assert(hits[1].dl.endsWith('tab=2'));
     assert.strictEqual(hits[1].ec, 'Page Visibility');
-    assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].ea, 'page load');
     assert.strictEqual(hits[1].ni, '1');
     assert.strictEqual(hits[1].cm1, '1');
   });
@@ -347,7 +347,7 @@ describe('pageVisibilityTracker', function() {
     assert.strictEqual(hits[0].cm1, '1');
     assert(hits[1].dl.endsWith('tab=2'));
     assert.strictEqual(hits[1].ec, 'Page Visibility');
-    assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].ea, 'page load');
     assert.strictEqual(hits[1].ni, '1');
     assert.strictEqual(hits[1].cm1, '1');
     assert(hits[2].dl.endsWith('tab=1'));
@@ -401,7 +401,7 @@ describe('pageVisibilityTracker', function() {
     assert.strictEqual(hits[0].cm1, '1');
     assert(hits[1].dl.endsWith('tab=2'));
     assert.strictEqual(hits[1].ec, 'Page Visibility');
-    assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].ea, 'page load');
     assert.strictEqual(hits[1].ni, '1');
     assert.strictEqual(hits[1].cm1, '1');
     assert(hits[2].dl.endsWith('tab=2'));

--- a/test/e2e/page-visibility-tracker-test.js
+++ b/test/e2e/page-visibility-tracker-test.js
@@ -898,6 +898,9 @@ function openNewTab(url) {
  * @return {string} The tab ID.
  */
 function openNewTabInBackground(url) {
+  const browserCaps = browser.session().value;
+  const cmdKey = browserCaps.platform == 'MAC' ? '\uE03D' : '\uE009';
+
   const oldTabIds = browser.getTabIds();
   browser.execute((url) => {
     const a = document.createElement('a');
@@ -908,9 +911,9 @@ function openNewTabInBackground(url) {
     document.body.appendChild(a);
   }, url);
 
-  browser.keys(['\uE03D']);
+  browser.keys([cmdKey]);
   browser.element('#new-tab-link').click();
-  browser.keys(['\uE03D']);
+  browser.keys([cmdKey]);
 
   browser.pause(500);
   let backgroundTab;

--- a/test/e2e/page-visibility-tracker-test.js
+++ b/test/e2e/page-visibility-tracker-test.js
@@ -153,7 +153,8 @@ describe('pageVisibilityTracker', function() {
     assert.strictEqual(hits[0].t, 'pageview');
   });
 
-  it('does not send a session-expiry pageview on initial page load', function() {
+  it('does not send a session-expiry pageview on initial page load',
+      function() {
     if (!browserSupportsTabs()) return this.skip();
 
     browser.execute(ga.run, 'require', 'pageVisibilityTracker', TEST_OPTS);

--- a/test/e2e/page-visibility-tracker-test.js
+++ b/test/e2e/page-visibility-tracker-test.js
@@ -279,13 +279,13 @@ describe('pageVisibilityTracker', function() {
     assert.strictEqual(hits[2].t, 'pageview');
   });
 
-  it('sends a pageload metric when pageloadMetricIndex is set', function() {
+  it('sends a pageload metric when pageLoadMetricIndex is set', function() {
     if (!browserSupportsTabs()) return this.skip();
 
     const opts = {
       sendInitialPageview: true,
       visibleThreshold: 0,
-      pageloadMetricIndex: 1,
+      pageLoadMetricIndex: 1,
     };
 
     browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
@@ -316,7 +316,7 @@ describe('pageVisibilityTracker', function() {
     const opts = {
       sendInitialPageview: true,
       visibleThreshold: 0,
-      pageloadMetricIndex: 1,
+      pageLoadMetricIndex: 1,
     };
 
     browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);
@@ -363,7 +363,7 @@ describe('pageVisibilityTracker', function() {
     const opts = {
       sendInitialPageview: true,
       visibleThreshold: 0,
-      pageloadMetricIndex: 1,
+      pageLoadMetricIndex: 1,
     };
 
     browser.execute(ga.run, 'require', 'pageVisibilityTracker', opts);

--- a/test/e2e/page-visibility-tracker-test.js
+++ b/test/e2e/page-visibility-tracker-test.js
@@ -307,6 +307,7 @@ describe('pageVisibilityTracker', function() {
     assert(hits[1].dl.endsWith('tab=2'));
     assert.strictEqual(hits[1].ec, 'Page Visibility');
     assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].ni, '1');
     assert.strictEqual(hits[1].cm1, '1');
   });
 
@@ -347,6 +348,7 @@ describe('pageVisibilityTracker', function() {
     assert(hits[1].dl.endsWith('tab=2'));
     assert.strictEqual(hits[1].ec, 'Page Visibility');
     assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].ni, '1');
     assert.strictEqual(hits[1].cm1, '1');
     assert(hits[2].dl.endsWith('tab=1'));
     assert.strictEqual(hits[2].ec, 'Page Visibility');
@@ -400,6 +402,7 @@ describe('pageVisibilityTracker', function() {
     assert(hits[1].dl.endsWith('tab=2'));
     assert.strictEqual(hits[1].ec, 'Page Visibility');
     assert.strictEqual(hits[1].ea, 'pageload');
+    assert.strictEqual(hits[1].ni, '1');
     assert.strictEqual(hits[1].cm1, '1');
     assert(hits[2].dl.endsWith('tab=2'));
     assert.strictEqual(hits[2].t, 'pageview');


### PR DESCRIPTION
The PR introduces two new options to the `pageVisibilityTracker` plugin:

1. `sendInitialPageview`: which, when `true` will let this plugin be responsible for sending the initial pageview, and it will only do so when the page's visibility state is visible. This helps avoid false positives when a page is opened in a background tab and never actually viewed.
2. `pageloadMetricIndex`: since there are use cases for knowing both when a page was loaded and when it was viewed, this option allows you to define your own *Pageloads* custom metric that tracks pageloads separately from pageviews. If the page was loaded in the visible state, the pageload metric is sent with the initial pageview. If it's loaded in the hidden state, an event is sent with the action "pageload" and the custom pageload metric.