### PR TITLE
Add a queryParamsWhitelist option

### DIFF
--- a/docs/plugins/clean-url-tracker.md
+++ b/docs/plugins/clean-url-tracker.md
@@ -66,6 +66,13 @@ The following table outlines all possible configuration options for the `cleanUr
     </td>
   </tr>
   <tr valign="top">
+    <td><code>queryParamWhitelist</code></td>
+    <td><code>Array</code></td>
+    <td>
+      An array of query params not to strip. This is most commonly used in conjunction with site search, as shown in the <a href=""><code>queryParamWhitelist</code> example</a> below.
+    </td>
+  </tr>
+  <tr valign="top">
     <td><code>queryDimensionIndex</code></td>
     <td><code>number</code></td>
     <td>
@@ -153,6 +160,26 @@ And given those four URLs, the following fields would be sent to Google Analytic
       "page": "/contact"
     }
 ```
+
+### Using the `queryParamsWhitelist` option
+
+Unlike campaign (e.g. `utm` params) and adwords (e.g. `glclid`) data, [Site Search](https://support.google.com/analytics/answer/1012264) data is not inferred by Google Analytics from the `location` field when the `page` field is present, so any site search query params *must not* be stripped from the `page` field.
+
+You can preserve individual query params via the `queryParamsWhitelist` option:
+
+```js
+ga('require', 'cleanUrlTracker', {
+  stripQuery: true,
+  queryParamsWhitelist: ['q'],
+});
+```
+
+Note that *not* stripping site search params from your URLs means those params will still show up in your page reports. If you don't want this to happen you can update your view's [Site Search setup](https://support.google.com/analytics/answer/1012264) as follows:
+
+1. Specify the same parameter(s) you set in the `queryParamsWhitelist` option.
+2. Check the "Strip query parameters out of URL" box.
+
+These options combined will allow you to keep all unwanted query params out of your page reports and still use site search.
 
 ### Using the `urlFieldsFilter` option
 

--- a/docs/plugins/clean-url-tracker.md
+++ b/docs/plugins/clean-url-tracker.md
@@ -66,10 +66,10 @@ The following table outlines all possible configuration options for the `cleanUr
     </td>
   </tr>
   <tr valign="top">
-    <td><code>queryParamWhitelist</code></td>
+    <td><code>queryParamsWhitelist</code></td>
     <td><code>Array</code></td>
     <td>
-      An array of query params not to strip. This is most commonly used in conjunction with site search, as shown in the <a href=""><code>queryParamWhitelist</code> example</a> below.
+      An array of query params not to strip. This is most commonly used in conjunction with site search, as shown in the <a href=""><code>queryParamsWhitelist</code> example</a> below.
     </td>
   </tr>
   <tr valign="top">

--- a/lib/externs/clean-url-tracker.js
+++ b/lib/externs/clean-url-tracker.js
@@ -2,6 +2,7 @@
  * Public options for the CleanUrlTracker.
  * @typedef {{
  *   stripQuery: (boolean|undefined),
+ *   siteSearchQueryParams: (Array|unefined),
  *   queryDimensionIndex: (number|undefined),
  *   indexFilename: (string|undefined),
  *   trailingSlash: (string|undefined),

--- a/lib/externs/clean-url-tracker.js
+++ b/lib/externs/clean-url-tracker.js
@@ -2,7 +2,7 @@
  * Public options for the CleanUrlTracker.
  * @typedef {{
  *   stripQuery: (boolean|undefined),
- *   queryParamsWhitelist: (Array|unefined),
+ *   queryParamsWhitelist: (Array|undefined),
  *   queryDimensionIndex: (number|undefined),
  *   indexFilename: (string|undefined),
  *   trailingSlash: (string|undefined),

--- a/lib/externs/clean-url-tracker.js
+++ b/lib/externs/clean-url-tracker.js
@@ -2,7 +2,7 @@
  * Public options for the CleanUrlTracker.
  * @typedef {{
  *   stripQuery: (boolean|undefined),
- *   siteSearchQueryParams: (Array|unefined),
+ *   queryParamsWhitelist: (Array|unefined),
  *   queryDimensionIndex: (number|undefined),
  *   indexFilename: (string|undefined),
  *   trailingSlash: (string|undefined),

--- a/lib/plugins/clean-url-tracker.js
+++ b/lib/plugins/clean-url-tracker.js
@@ -42,6 +42,7 @@ class CleanUrlTracker {
     /** @type {CleanUrlTrackerOpts} */
     const defaultOpts = {
       // stripQuery: undefined,
+      // siteSearchQueryParams: undefined,
       // queryDimensionIndex: undefined,
       // indexFilename: undefined,
       // trailingSlash: undefined,
@@ -140,7 +141,8 @@ class CleanUrlTracker {
 
     /** @type {!FieldsObj} */
     const cleanedFieldsObj = {
-      page: pathname + (!this.opts.stripQuery ? url.search : ''),
+      page: pathname + (this.opts.stripQuery ?
+          this.stripNonSiteSearchParams(url.search) : url.search),
     };
     if (fieldsObj.location) {
       cleanedFieldsObj.location = fieldsObj.location;
@@ -157,13 +159,41 @@ class CleanUrlTracker {
           this.opts.urlFieldsFilter(cleanedFieldsObj, parseUrl);
 
       // Ensure only the URL fields are returned.
-      return {
+      const returnValue = {
         page: userCleanedFieldsObj.page,
         location: userCleanedFieldsObj.location,
-        [this.queryDimension]: userCleanedFieldsObj[this.queryDimension],
       };
+      if (this.queryDimension) {
+        returnValue[this.queryDimension] =
+            userCleanedFieldsObj[this.queryDimension];
+      }
+      return returnValue;
     } else {
       return cleanedFieldsObj;
+    }
+  }
+
+  /**
+   * Accpets a raw URL search string and returns a new search string containing
+   * only the site search params (if they exist).
+   * @param {string} searchString A whitelist of URL params.
+   * @param {string} search The URL search string (starting with '?').
+   * @return {string} The query string
+   */
+  stripNonSiteSearchParams(searchString) {
+    if (Array.isArray(this.opts.siteSearchQueryParams)) {
+      const foundParams = [];
+      searchString.slice(1).split('&').forEach((kv) => {
+        const [key, value] = kv.split('=');
+        if (this.opts.siteSearchQueryParams.indexOf(key) > -1 && value) {
+          foundParams.push([key, value]);
+        }
+      });
+
+      return foundParams.length ?
+          '?' + foundParams.map((kv) => kv.join('=')).join('&') : '';
+    } else {
+      return '';
     }
   }
 

--- a/lib/plugins/clean-url-tracker.js
+++ b/lib/plugins/clean-url-tracker.js
@@ -42,7 +42,7 @@ class CleanUrlTracker {
     /** @type {CleanUrlTrackerOpts} */
     const defaultOpts = {
       // stripQuery: undefined,
-      // siteSearchQueryParams: undefined,
+      // queryParamsWhitelist: undefined,
       // queryDimensionIndex: undefined,
       // indexFilename: undefined,
       // trailingSlash: undefined,
@@ -142,7 +142,7 @@ class CleanUrlTracker {
     /** @type {!FieldsObj} */
     const cleanedFieldsObj = {
       page: pathname + (this.opts.stripQuery ?
-          this.stripNonSiteSearchParams(url.search) : url.search),
+          this.stripNonWhitelistedQueryParams(url.search) : url.search),
     };
     if (fieldsObj.location) {
       cleanedFieldsObj.location = fieldsObj.location;
@@ -180,12 +180,12 @@ class CleanUrlTracker {
    * @param {string} search The URL search string (starting with '?').
    * @return {string} The query string
    */
-  stripNonSiteSearchParams(searchString) {
-    if (Array.isArray(this.opts.siteSearchQueryParams)) {
+  stripNonWhitelistedQueryParams(searchString) {
+    if (Array.isArray(this.opts.queryParamsWhitelist)) {
       const foundParams = [];
       searchString.slice(1).split('&').forEach((kv) => {
         const [key, value] = kv.split('=');
-        if (this.opts.siteSearchQueryParams.indexOf(key) > -1 && value) {
+        if (this.opts.queryParamsWhitelist.indexOf(key) > -1 && value) {
           foundParams.push([key, value]);
         }
       });

--- a/lib/plugins/clean-url-tracker.js
+++ b/lib/plugins/clean-url-tracker.js
@@ -176,8 +176,7 @@ class CleanUrlTracker {
   /**
    * Accpets a raw URL search string and returns a new search string containing
    * only the site search params (if they exist).
-   * @param {string} searchString A whitelist of URL params.
-   * @param {string} search The URL search string (starting with '?').
+   * @param {string} searchString The URL search string (starting with '?').
    * @return {string} The query string
    */
   stripNonWhitelistedQueryParams(searchString) {

--- a/test/e2e/clean-url-tracker-test.js
+++ b/test/e2e/clean-url-tracker-test.js
@@ -176,7 +176,7 @@ describe('cleanUrlTracker', function() {
 function requireCleanUrlTracker_multipleOpts() {
   ga('require', 'cleanUrlTracker', {
     stripQuery: true,
-    siteSearchQueryParams: ['q', 's'],
+    queryParamsWhitelist: ['q', 's'],
     queryDimensionIndex: 1,
     indexFilename: 'index.html',
     trailingSlash: 'remove',

--- a/test/e2e/clean-url-tracker-test.js
+++ b/test/e2e/clean-url-tracker-test.js
@@ -66,68 +66,6 @@ describe('cleanUrlTracker', function() {
     assert.strictEqual(hits[0].dp, '/foo/bar?q=qux&b=baz');
   });
 
-  it('supports removing the query string from the URL path', () => {
-    const url = 'https://example.com/foo/bar?q=qux&b=baz#hash';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      stripQuery: true,
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dl, url);
-    assert.strictEqual(hits[0].dp, '/foo/bar');
-  });
-
-  it('optionally adds the query string as a custom dimension', () => {
-    const url = 'https://example.com/foo/bar?q=qux&b=baz#hash';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      stripQuery: true,
-      queryDimensionIndex: 1,
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dl, url);
-    assert.strictEqual(hits[0].dp, '/foo/bar');
-    assert.strictEqual(hits[0].cd1, 'q=qux&b=baz');
-  });
-
-  it('adds the null dimensions when no query string is found', () => {
-    const url = 'https://example.com/foo/bar';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      stripQuery: true,
-      queryDimensionIndex: 1,
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dl, url);
-    assert.strictEqual(hits[0].dp, '/foo/bar');
-    assert.strictEqual(hits[0].cd1, constants.NULL_DIMENSION);
-  });
-
-  it('does not set a dimension if strip query is false', () => {
-    const url = 'https://example.com/foo/bar?q=qux&b=baz#hash';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      stripQuery: false,
-      queryDimensionIndex: 1,
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dl, url);
-    assert.strictEqual(hits[0].dp, '/foo/bar?q=qux&b=baz');
-    assert.strictEqual(hits[0].cd1, undefined);
-  });
-
   it('cleans URLs in all hits, not just the initial pageview', () => {
     const url = 'https://example.com/foo/bar?q=qux&b=baz#hash';
     browser.execute(ga.run, 'set', 'location', url);
@@ -176,76 +114,6 @@ describe('cleanUrlTracker', function() {
     assert.strictEqual(hits[1].cd1, 'query=new');
   });
 
-  it('supports removing index filenames', () => {
-    const url = 'https://example.com/foo/bar/index.html?q=qux&b=baz#hash';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      indexFilename: 'index.html',
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dp, '/foo/bar/?q=qux&b=baz');
-  });
-
-  it('only removes index filenames at the end of the URL after a slash', () => {
-    const url = 'https://example.com/noindex.html';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      indexFilename: 'index.html',
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dp, '/noindex.html');
-  });
-
-  it('supports stripping trailing slashes', () => {
-    const url = 'https://example.com/foo/bar/';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      trailingSlash: 'remove',
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dp, '/foo/bar');
-  });
-
-  it('supports adding trailing slashes to non-filename URLs', () => {
-    const url = 'https://example.com/foo/bar?q=qux&b=baz#hash';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(ga.run, 'require', 'cleanUrlTracker', {
-      stripQuery: true,
-      queryDimensionIndex: 1,
-      trailingSlash: 'add',
-    });
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.execute(ga.run, 'set', 'page', '/foo/bar.html');
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(2));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dp, '/foo/bar/');
-    assert.strictEqual(hits[1].dp, '/foo/bar.html');
-  });
-
-  it('supports generically filtering all URL fields', () => {
-    const url = 'https://example.com/foo/bar?q=qux&b=baz#hash';
-    browser.execute(ga.run, 'set', 'location', url);
-    browser.execute(requireCleanUrlTracker_urlFieldsFilter);
-    browser.execute(ga.run, 'send', 'pageview');
-    browser.waitUntil(log.hitCountEquals(1));
-
-    const hits = log.getHits();
-    assert.strictEqual(hits[0].dl,
-        'https://example.io/foo/bar?q=qux&b=baz#hash');
-    assert.strictEqual(hits[0].dp, '/foo/bar');
-  });
-
   it('works with many options in conjunction with each other', () => {
     const url = 'https://example.com/path/to/index.html?q=qux&b=baz#hash';
     browser.execute(ga.run, 'set', 'location', url);
@@ -256,7 +124,7 @@ describe('cleanUrlTracker', function() {
     const hits = log.getHits();
     assert.strictEqual(hits[0].dl,
         'https://example.io/path/to/index.html?q=qux&b=baz#hash');
-    assert.strictEqual(hits[0].dp, '/path/to');
+    assert.strictEqual(hits[0].dp, '/path/to?q=qux');
     assert.strictEqual(hits[0].cd1, 'q=qux&b=baz');
   });
 
@@ -305,31 +173,10 @@ describe('cleanUrlTracker', function() {
  * client, this one-off function must be used to set the value for
  * `urlFieldsFilter`.
  */
-function requireCleanUrlTracker_urlFieldsFilter() {
-  ga('require', 'cleanUrlTracker', {
-    urlFieldsFilter: (fieldsObj, parseUrl) => {
-      fieldsObj.page = parseUrl(fieldsObj.location).pathname;
-
-      const url = parseUrl(fieldsObj.location);
-      if (url.hostname == 'example.com') {
-        fieldsObj.location =
-            `${url.protocol}//example.io` +
-            `${url.pathname}${url.search}${url.hash}`;
-      }
-      return fieldsObj;
-    },
-  });
-}
-
-
-/**
- * Since function objects can't be passed via parameters from server to
- * client, this one-off function must be used to set the value for
- * `urlFieldsFilter`.
- */
 function requireCleanUrlTracker_multipleOpts() {
   ga('require', 'cleanUrlTracker', {
     stripQuery: true,
+    siteSearchQueryParams: ['q', 's'],
     queryDimensionIndex: 1,
     indexFilename: 'index.html',
     trailingSlash: 'remove',

--- a/test/unit/plugins/clean-url-tracker-test.js
+++ b/test/unit/plugins/clean-url-tracker-test.js
@@ -66,7 +66,7 @@ describe('CleanUrlTracker', () => {
       const fn = () => {};
       const opts = {
         stripQuery: true,
-        siteSearchQueryParams: ['q', 's'],
+        queryParamsWhitelist: ['q', 's'],
         queryDimensionIndex: 1,
         indexFilename: 'index.html',
         trailingSlash: 'remove',
@@ -106,61 +106,62 @@ describe('CleanUrlTracker', () => {
     });
   });
 
-  describe('stripNonSiteSearchParams', () => {
-    it('returns a URL search string with only site search params', () => {
+  describe('stripNonWhitelistedQueryParams', () => {
+    it('returns a URL search string with only whitelisted params', () => {
       const cut = new CleanUrlTracker(tracker, {
-        siteSearchQueryParams: ['q', 's'],
+        queryParamsWhitelist: ['q', 's'],
       });
 
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?gclid=foo'), '');
+          cut.stripNonWhitelistedQueryParams('?gclid=foo'), '');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?gclid=foo&q=1'), '?q=1');
+          cut.stripNonWhitelistedQueryParams('?gclid=foo&q=1'), '?q=1');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?q=1&gclid=foo'), '?q=1');
+          cut.stripNonWhitelistedQueryParams('?q=1&gclid=foo'), '?q=1');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?gclid=foo&q=1&s=2'),
+          cut.stripNonWhitelistedQueryParams('?gclid=foo&q=1&s=2'),
           '?q=1&s=2');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?q=1&gclid=foo&s=2'), '?q=1&s=2');
+          cut.stripNonWhitelistedQueryParams('?q=1&gclid=foo&s=2'), '?q=1&s=2');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?q=1&s=2&gclid=foo'), '?q=1&s=2');
+          cut.stripNonWhitelistedQueryParams('?q=1&s=2&gclid=foo'), '?q=1&s=2');
 
       cut.remove();
     });
 
     it('does not modify URL encoded keys or values', () => {
       const cut = new CleanUrlTracker(tracker, {
-        siteSearchQueryParams: ['q', 's'],
+        queryParamsWhitelist: ['q', 's'],
       });
 
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?gclid=foo&q=1%202'), '?q=1%202');
+          cut.stripNonWhitelistedQueryParams('?gclid=foo&q=1%202'), '?q=1%202');
 
       cut.remove();
     });
 
     it('works with empty or missing param values', () => {
       const cut = new CleanUrlTracker(tracker, {
-        siteSearchQueryParams: ['q', 's'],
+        queryParamsWhitelist: ['q', 's'],
       });
 
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?q=1&s=2&gclid=foo'), '?q=1&s=2');
+          cut.stripNonWhitelistedQueryParams('?q=1&s=2&gclid=foo'), '?q=1&s=2');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?q&s=&gclid=foo'), '');
+          cut.stripNonWhitelistedQueryParams('?q&s=&gclid=foo'), '');
 
       cut.remove();
     });
 
-    it('works when the siteSearchQueryParams option is not set', () => {
+    it('works when the queryParamsWhitelist option is not set', () => {
       const cut = new CleanUrlTracker(tracker);
 
-      assert.strictEqual(cut.stripNonSiteSearchParams('?utm_source=foo'), '');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?utm_source=foo&q=1'), '');
+          cut.stripNonWhitelistedQueryParams('?utm_source=foo'), '');
       assert.strictEqual(
-          cut.stripNonSiteSearchParams('?utm_source=foo&q=1&s=2'), '');
+          cut.stripNonWhitelistedQueryParams('?utm_source=foo&q=1'), '');
+      assert.strictEqual(
+          cut.stripNonWhitelistedQueryParams('?utm_source=foo&q=1&s=2'), '');
 
       cut.remove();
     });

--- a/test/unit/plugins/clean-url-tracker-test.js
+++ b/test/unit/plugins/clean-url-tracker-test.js
@@ -56,8 +56,6 @@ describe('CleanUrlTracker', () => {
     });
 
     it('merges the passed options with the defaults', () => {
-      if (!document.visibilityState) this.skip();
-
       let cut = new CleanUrlTracker(tracker);
 
       assert.deepEqual(cut.opts, {});

--- a/test/unit/plugins/clean-url-tracker-test.js
+++ b/test/unit/plugins/clean-url-tracker-test.js
@@ -1,0 +1,398 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import assert from 'assert';
+import sinon from 'sinon';
+import * as constants from '../../../lib/constants';
+import '../../../lib/plugins/clean-url-tracker';
+
+
+const DEFAULT_TRACKER_FIELDS = {
+  trackingId: 'UA-12345-1',
+  cookieDomain: 'auto',
+  siteSpeedSampleRate: 0,
+};
+
+
+describe('CleanUrlTracker', () => {
+  let tracker;
+  let CleanUrlTracker;
+
+  beforeEach((done) => {
+    localStorage.clear();
+    window.ga('create', DEFAULT_TRACKER_FIELDS);
+    window.ga((t) => {
+      tracker = t;
+      CleanUrlTracker = window.gaplugins.CleanUrlTracker;
+      done();
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    window.ga('remove');
+  });
+
+  describe('constructor', () => {
+    it('stores the tracker on the instance', () => {
+      const cut = new CleanUrlTracker(tracker);
+      assert.strictEqual(tracker, cut.tracker);
+
+      cut.remove();
+    });
+
+    it('merges the passed options with the defaults', () => {
+      if (!document.visibilityState) this.skip();
+
+      let cut = new CleanUrlTracker(tracker);
+
+      assert.deepEqual(cut.opts, {});
+      cut.remove();
+
+      const fn = () => {};
+      const opts = {
+        stripQuery: true,
+        siteSearchQueryParams: ['q', 's'],
+        queryDimensionIndex: 1,
+        indexFilename: 'index.html',
+        trailingSlash: 'remove',
+        urlFilter: fn,
+      };
+      cut = new CleanUrlTracker(tracker, opts);
+      assert.deepEqual(cut.opts, opts);
+      cut.remove();
+    });
+
+    it('overrides the tracker\'s get method', () => {
+      tracker.set('location', 'https://example.com/test?foo=bar');
+      assert(!tracker.get('page'));
+
+      const originalTrackerGet = tracker.get;
+      const cut = new CleanUrlTracker(tracker, {
+        stripQuery: true,
+      });
+
+      assert.notStrictEqual(tracker.get, originalTrackerGet);
+      assert.strictEqual(tracker.get('page'), '/test');
+
+      cut.remove();
+    });
+
+    it('overrides the tracker\'s buildHitTask function', () => {
+      const originalTrackerGet = tracker.get('buildHitTask');
+      const cut = new CleanUrlTracker(tracker);
+      assert.notStrictEqual(tracker.get('buildHitTask'), originalTrackerGet);
+
+      const spy = sinon.spy(cut, 'cleanUrlFields');
+      tracker.send('pageview');
+
+      assert(spy.calledOnce);
+
+      cut.remove();
+    });
+  });
+
+  describe('stripNonSiteSearchParams', () => {
+    it('returns a URL search string with only site search params', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        siteSearchQueryParams: ['q', 's'],
+      });
+
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?gclid=foo'), '');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?gclid=foo&q=1'), '?q=1');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?q=1&gclid=foo'), '?q=1');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?gclid=foo&q=1&s=2'),
+          '?q=1&s=2');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?q=1&gclid=foo&s=2'), '?q=1&s=2');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?q=1&s=2&gclid=foo'), '?q=1&s=2');
+
+      cut.remove();
+    });
+
+    it('does not modify URL encoded keys or values', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        siteSearchQueryParams: ['q', 's'],
+      });
+
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?gclid=foo&q=1%202'), '?q=1%202');
+
+      cut.remove();
+    });
+
+    it('works with empty or missing param values', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        siteSearchQueryParams: ['q', 's'],
+      });
+
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?q=1&s=2&gclid=foo'), '?q=1&s=2');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?q&s=&gclid=foo'), '');
+
+      cut.remove();
+    });
+
+    it('works when the siteSearchQueryParams option is not set', () => {
+      const cut = new CleanUrlTracker(tracker);
+
+      assert.strictEqual(cut.stripNonSiteSearchParams('?utm_source=foo'), '');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?utm_source=foo&q=1'), '');
+      assert.strictEqual(
+          cut.stripNonSiteSearchParams('?utm_source=foo&q=1&s=2'), '');
+
+      cut.remove();
+    });
+  });
+
+  describe('cleanUrlFields', () => {
+    it('returns a fieldsObj with the URL fields set', () => {
+      const cut = new CleanUrlTracker(tracker);
+      const ret = cut.cleanUrlFields({
+        location: 'https://example.com/test?foo=bar',
+      });
+
+      assert(typeof ret == 'object');
+      assert(ret.hasOwnProperty('location'));
+      assert(ret.hasOwnProperty('page'));
+
+      cut.remove();
+    });
+
+    it('sets the page field but does not modify the path by default', () => {
+      const cut = new CleanUrlTracker(tracker);
+      const location = 'https://example.com/foo/bar?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar?q=qux&b=baz',
+      });
+
+      cut.remove();
+    });
+
+    it('supports removing the query string from the URL path', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        stripQuery: true,
+      });
+      const location = 'https://example.com/foo/bar?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar',
+      });
+
+      cut.remove();
+    });
+
+    it('optionally returns the query string as a custom dimension', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        stripQuery: true,
+        queryDimensionIndex: 1,
+      });
+      const location = 'https://example.com/foo/bar?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar',
+        dimension1: 'q=qux&b=baz',
+      });
+
+      cut.remove();
+    });
+
+    it('returns the null dimensions when no query string is found', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        stripQuery: true,
+        queryDimensionIndex: 1,
+      });
+      const location = 'https://example.com/foo/bar';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar',
+        dimension1: constants.NULL_DIMENSION,
+      });
+
+      cut.remove();
+    });
+
+    it('does not set a dimension if strip query is false', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        stripQuery: false,
+        queryDimensionIndex: 1,
+      });
+      const location = 'https://example.com/foo/bar?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar?q=qux&b=baz',
+      });
+
+      cut.remove();
+    });
+
+    it('supports removing index filenames', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        indexFilename: 'index.html',
+      });
+      const location =
+          'https://example.com/foo/bar/index.html?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar/?q=qux&b=baz',
+      });
+
+      cut.remove();
+    });
+
+    it('only removes index filenames at the end of the URL after a slash',
+        () => {
+      const cut = new CleanUrlTracker(tracker, {
+        indexFilename: 'index.html',
+      });
+      const location = 'https://example.com/noindex.html';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/noindex.html',
+      });
+
+      cut.remove();
+    });
+
+    it('supports stripping trailing slashes', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        trailingSlash: 'remove',
+      });
+      const location = 'https://example.com/foo/bar/';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar',
+      });
+
+      cut.remove();
+    });
+
+    it('supports adding trailing slashes to non-filename URLs', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        stripQuery: true,
+        trailingSlash: 'add',
+      });
+      const location = 'https://example.com/foo/bar?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location,
+        page: '/foo/bar/',
+      });
+
+      assert.deepEqual(cut.cleanUrlFields({
+        location,
+        page: '/foo/bar.html',
+      }), {
+        location,
+        page: '/foo/bar.html',
+      });
+
+      cut.remove();
+    });
+
+    it('supports programmatically filtering URL fields', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        urlFieldsFilter: (fieldsObj, parseUrl) => {
+          fieldsObj.page = parseUrl(fieldsObj.location).pathname;
+
+          const url = parseUrl(fieldsObj.location);
+          if (url.hostname == 'example.com') {
+            fieldsObj.location =
+                `${url.protocol}//example.io` +
+                `${url.pathname}${url.search}${url.hash}`;
+          }
+          return fieldsObj;
+        },
+      });
+      const location = 'https://example.com/foo/bar?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location: 'https://example.io/foo/bar?q=qux&b=baz#hash',
+        page: '/foo/bar',
+      });
+
+      cut.remove();
+    });
+
+    it('works with many options in conjunction with each other', () => {
+      const cut = new CleanUrlTracker(tracker, {
+        stripQuery: true,
+        queryDimensionIndex: 1,
+        indexFilename: 'index.html',
+        trailingSlash: 'remove',
+        urlFieldsFilter: (fieldsObj, parseUrl) => {
+          const url = parseUrl(fieldsObj.location);
+          if (url.hostname == 'example.com') {
+            fieldsObj.location =
+                `${url.protocol}//example.io` +
+                `${url.pathname}${url.search}${url.hash}`;
+          }
+          return fieldsObj;
+        },
+      });
+      const location =
+          'https://example.com/path/to/index.html?q=qux&b=baz#hash';
+
+      assert.deepEqual(cut.cleanUrlFields({location}), {
+        location: 'https://example.io/path/to/index.html?q=qux&b=baz#hash',
+        page: '/path/to',
+        dimension1: 'q=qux&b=baz',
+      });
+
+      cut.remove();
+    });
+  });
+
+  describe('remove', () => {
+    it('restores the tracker\'s get method', () => {
+      const originalTrackerGet = tracker.get;
+      const cut = new CleanUrlTracker(tracker);
+
+      assert.notStrictEqual(tracker.get, originalTrackerGet);
+
+      cut.remove();
+
+      assert.strictEqual(tracker.get, originalTrackerGet);
+    });
+
+    it('restores the tracker\'s buildHitTask function', () => {
+      const originalTrackerGet = tracker.get('buildHitTask');
+      const cut = new CleanUrlTracker(tracker);
+      assert.notStrictEqual(tracker.get('buildHitTask'), originalTrackerGet);
+
+      cut.remove();
+
+      assert.strictEqual(tracker.get('buildHitTask'), originalTrackerGet);
+    });
+  });
+});


### PR DESCRIPTION
Addresses the issue brought up in #176 by adding a `queryParamsWhitelist` configuration option to the `cleanUrlTracker` plugin.