### PR TITLE
Fix MaxScrollTracker interactive events docs

### DIFF
--- a/docs/plugins/max-scroll-tracker.md
+++ b/docs/plugins/max-scroll-tracker.md
@@ -174,8 +174,8 @@ ga('require', 'maxScrollTracker', {
   hitFilter: function(model) {
     var scrollPercentage = model.get('eventLabel');
     if (scrollPercentage > 50) {
-      // Sets the nonInteractive field to `true` for the current hit.
-      model.set('nonInteraction', true, true);
+      // Sets the nonInteractive field to `false` for the current hit.
+      model.set('nonInteraction', false, true);
     }
   },
 });


### PR DESCRIPTION
The "Making scroll events interactive beyond 50%" documentation was incorrect
as it was setting the "nonInteraction" property to "true", which in turn does
not make the next events interactive. Fix the value, and also corrected the
comment.