### PR TITLE
Fix typo in mac-scroll-tracker calculated metric formula

### DIFF
--- a/docs/plugins/max-scroll-tracker.md
+++ b/docs/plugins/max-scroll-tracker.md
@@ -41,7 +41,7 @@ The easiest way to track max scroll percentage is to create a [custom metric](ht
 Since the max scroll tracker plugin only reports a single max scroll percentage per unique page path per session, you can calculate the average max scroll percentage for any dimension by dividing the value of your *Max Scroll Percentage* custom metric by the *Unique Pageviews* metrics. Here's what the formula looks like:
 
 ```
-{{Max Scroll Percentage}} / ( 100 * {{Unique Pageviews}} )
+{{Max Scroll Percentage}} / ( 100 * {{Unique Page Views}} )
 ```
 
 The screenshot in the [overview](#overview) shows some examples of what reports with these custom and calculated metrics look like.


### PR DESCRIPTION
The previous formula throws an error: `Metric not found: 'Unique Pageviews'.`. Either the metric has been renamed, or there was a typo in the docs.

Screenshot for posterity:

<img width="442" alt="max-scroll-percentage" src="https://user-images.githubusercontent.com/877585/33500152-7defdbf2-d6e0-11e7-8f0b-d2445a20ec9c.png">
