### PR TITLE
impression docs: Missing trailing - in attribute prefix

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -74,7 +74,7 @@ ga('require', 'eventTracker', {
 ```js
 ga('require', 'impressionTracker', {
   elements: ['cta'],
-  attributePrefix: 'data-ga'
+  attributePrefix: 'data-ga-'
 });
 ```
 


### PR DESCRIPTION
without this - i get an error from google-analytics that says "EventCategory" is not a valid set property (notice the big E instead of e)