### PR TITLE
Fix: Keep order of metrics consistent

### DIFF
--- a/docs/plugins/page-visibility-tracker.md
+++ b/docs/plugins/page-visibility-tracker.md
@@ -53,16 +53,16 @@ ga('require', 'pageVisibilityTracker', options);
 
 The easiest way to track the time a page was visible is to create a [custom metric](https://support.google.com/analytics/answer/2709828) called *Page Visible Time* that you set in your plugin configuration options, and then to create [calculated metrics](https://support.google.com/analytics/answer/6121409) called *Avg. Page Visible Time (per Page)* and *Avg. Page Visible Time (per Session)* that you use in your reports.
 
-Which calculated metric you need will depend on which dimensions you're using in your report. For session-level dimensions (e.g. *Referrer* or *Device Category*) you'll want to use the session version, and for page-specific dimensions (e.g. *Page* or *Title*) you'll want to use the page version.
+Which calculated metric you need will depend on which dimensions you're using in your report. For page-specific dimensions (e.g. *Page* or *Title*) you'll want to use the page version, and for session-level dimensions (e.g. *Referrer* or *Device Category*) you'll want to use the session version.
 
 Here are the formulas for both:
 
 ```
-{{Page Visible Time}} / {{Sessions}}
+{{Page Visible Time}} / {{Unique Pageviews}}
 ```
 
 ```
-{{Page Visible Time}} / {{Unique Pageviews}}
+{{Page Visible Time}} / {{Sessions}}
 ```
 
 The screenshots in the [overview](#overview) shows some examples of what reports with these custom and calculated metrics look like.


### PR DESCRIPTION
This PR

* [x] keeps the order of metrics consistent

💁‍♂️ As of the moment, the documentation mentions the calculated metrics in the order

* *Avg. Page Visible Time (per Page)* 
* *Avg. Page Visible Time (per Session)*

![screen shot 2018-05-16 at 21 09 19](https://user-images.githubusercontent.com/605483/40138610-7af3b758-594d-11e8-9f0c-f93422b1bad6.png)

but then provides the formulas in reverse order

* *Avg. Page Visible Time (per Session)*
* *Avg. Page Visible Time (per Page)* 

![screen shot 2018-05-16 at 21 09 28](https://user-images.githubusercontent.com/605483/40138625-83537596-594d-11e8-9741-ff4cef6d0047.png)

To reduce the confusion (and possibly, mistakes when people skim the documentation), I propose to reserve the order of the formulas.