### PR TITLE
Fixed Facebook social interaction tracking.

### DIFF
--- a/lib/plugins/social-widget-tracker.js
+++ b/lib/plugins/social-widget-tracker.js
@@ -55,8 +55,7 @@ class SocialWidgetTracker {
     this.addTwitterEventHandlers = this.addTwitterEventHandlers.bind(this);
     this.handleTweetEvents = this.handleTweetEvents.bind(this);
     this.handleFollowEvents = this.handleFollowEvents.bind(this);
-    this.handleLikeEvents = this.handleLikeEvents.bind(this);
-    this.handleUnlikeEvents = this.handleUnlikeEvents.bind(this);
+    this.handleFacebookEvents = this.handleFacebookEvents.bind(this);
 
     this.queue = TrackerQueue.getOrCreate(tracker.get('trackingId'));
 
@@ -78,7 +77,7 @@ class SocialWidgetTracker {
    */
   addWidgetListeners() {
     this.queue.pushTask(() => {
-      if (window.FB) this.addFacebookEventHandlers();
+      this.addFacebookEventHandlers();
       if (window.twttr) this.addTwitterEventHandlers();
     });
   }
@@ -119,12 +118,7 @@ class SocialWidgetTracker {
    * official Facebook like button.
    */
   addFacebookEventHandlers() {
-    try {
-      window.FB.Event.subscribe('edge.create', this.handleLikeEvents);
-      window.FB.Event.subscribe('edge.remove', this.handleUnlikeEvents);
-    } catch (err) {
-      // Do nothing.
-    }
+    window.addEventListener('blur', handleFacebookEvents);
   }
 
   /**
@@ -132,12 +126,7 @@ class SocialWidgetTracker {
    * official Facebook like button.
    */
   removeFacebookEventHandlers() {
-    try {
-      window.FB.Event.unsubscribe('edge.create', this.handleLikeEvents);
-      window.FB.Event.unsubscribe('edge.remove', this.handleUnlikeEvents);
-    } catch (err) {
-      // Do nothing.
-    }
+    window.removeEventListener('blur', handleFacebookEvents);
   }
 
   /**
@@ -193,41 +182,39 @@ class SocialWidgetTracker {
   }
 
   /**
-   * Handles `like` events emitted by the Facebook JS SDK.
-   * @param {string} url The URL corresponding to the like event.
+   * Handles events of embedded Facebook `like` and `share` widgets.
+   *
+   * Due to privacy issues Facebook decided to deprecate a particular solution
+   * which allows to track clicks of native buttons embedded by Facebook JS SDK.
+   * @param {Event} event The window blur event.
+   *
+   * @see https://developers.facebook.com/blog/post/2017/11/07/changes-developer-offerings/
    */
-  handleLikeEvents(url) {
-    this.queue.pushTask(({time}) => {
-      /** @type {FieldsObj} */
-      const defaultFields = {
-        transport: 'beacon',
-        socialNetwork: 'Facebook',
-        socialAction: 'like',
-        socialTarget: url,
-        queueTime: now() - time,
-      };
-      this.tracker.send('social', createFieldsObj(defaultFields,
-          this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
-    });
-  }
+  handleFacebookEvents(event) {
+    /** @type {HTMLElement} */ var iframe = document.activeElement;
+    if (iframe && iframe.tagName == 'IFRAME') {
+      if (iframe.src.indexOf('https://www.facebook.com/' == 0)) {
+        // Possible iframe titles:
+        // "fb:like Facebook Social Plugin"
+        // "fb:share_button Facebook Social Plugin"
+        var action = iframe.title.split(' ')[0];
+        if (action.indexOf('fb:') == 0) {
+          action = action.slice(3).split('_')[0];
 
-  /**
-   * Handles `unlike` events emitted by the Facebook JS SDK.
-   * @param {string} url The URL corresponding to the unlike event.
-   */
-  handleUnlikeEvents(url) {
-    this.queue.pushTask(({time}) => {
-      /** @type {FieldsObj} */
-      const defaultFields = {
-        transport: 'beacon',
-        socialNetwork: 'Facebook',
-        socialAction: 'unlike',
-        socialTarget: url,
-        queueTime: now() - time,
-      };
-      this.tracker.send('social', createFieldsObj(defaultFields,
-          this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
-    });
+          this.queue.pushTask(({time}) => {
+            /** @type {FieldsObj} */ const defaultFields = {
+              transport: 'beacon',
+              socialNetwork: 'Facebook',
+              socialAction: action,
+              socialTarget: location.href,
+              queueTime: now() - time,
+            };
+            this.tracker.send('social', createFieldsObj(defaultFields,
+                this.opts.fieldsObj, this.tracker, this.opts.hitFilter));
+          });
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Due to privacy issues Facebook decided to [deprecate](https://developers.facebook.com/blog/post/2017/11/07/changes-developer-offerings/) a particular solution which allows to track clicks of native buttons embedded by Facebook JS SDK.

My solution uses a different approach to achieve similar results.